### PR TITLE
Add possibility to create IPmask object while using Qt UI

### DIFF
--- a/src/console/main.cpp
+++ b/src/console/main.cpp
@@ -1,5 +1,7 @@
 #include <QCoreApplication>
 #include <iostream>
+#include <vector>
+#include <memory>
 
 #include "IPstructs.h"
 #include "SubnetsCalculatorV4.h"
@@ -14,11 +16,11 @@ int main(int argc, char *argv[])
     Networkv4 mainNetwork;
 
     std::cout << "Podaj adres IPv4 sieci glownej: ";
-    std::cin >> *mainNetwork.Ip;
+    std::cin >> mainNetwork.Ip;
     std::cout << "Podaj maske IPv4 sieci glownej: ";
-    std::cin >> *mainNetwork.NetMask;
+    std::cin >> mainNetwork.NetMask;
 
-    if(*mainNetwork.Ip != (*mainNetwork.Ip & *mainNetwork.NetMask))
+    if(*mainNetwork.Ip != *(mainNetwork.Ip & mainNetwork.NetMask))
     {
         throw NotImplemented{"TODO: error handling"}; //check if passed address is network address
     }

--- a/src/core/IIPaddress.h
+++ b/src/core/IIPaddress.h
@@ -3,7 +3,6 @@
 #define IIPADDRESS_H
 
 #include <QString>
-#include <iostream>
 
 namespace core{
     class IIPaddress

--- a/src/core/IIPaddress.h
+++ b/src/core/IIPaddress.h
@@ -12,15 +12,10 @@ namespace core{
         virtual QString asStringDec() const = 0;
         virtual QString asStringBin() const = 0;
 
-        friend std::ostream& operator<< (std::ostream& out, const IIPaddress& c)
-        {
-            out << c.asStringDec().toStdString() << std::flush;
-            return out;
-        };
-
     protected:
         IIPaddress& operator=(const IIPaddress&) = default;
         virtual ~IIPaddress() = default;
     };
 };
+
 #endif // IIPADDRESS_H

--- a/src/core/IIPmask.h
+++ b/src/core/IIPmask.h
@@ -1,0 +1,17 @@
+#pragma once
+#ifndef IIPMASK_H
+#define IIPMASK_H
+
+namespace core {
+    class IIPmask
+    {
+    public:
+        virtual short getPrefix() const = 0;
+
+    protected:
+        IIPmask& operator=(const IIPmask&) = default;
+        virtual ~IIPmask() = default;
+    };
+};
+
+#endif // IIPMASK_H

--- a/src/core/IIPparser.h
+++ b/src/core/IIPparser.h
@@ -3,17 +3,21 @@
 #define IIPPARSER_H
 
 #include <QString>
+#include <memory>
 
 namespace core{
-    template <class C>
+    class IPaddressBase; //forward declaration
+    class IPmaskBase; //forward declaration
+
     class IIPparser
     {
     public:
-        virtual C ipFromString(const QString&) const = 0;
-        virtual ~IIPparser() = default;
+        virtual std::shared_ptr<IPaddressBase> ipFromString(const QString&) const = 0;
+        virtual std::shared_ptr<IPmaskBase> ipMaskFromString(const QString&) const = 0;
 
     protected:
         IIPparser& operator=(const IIPparser&) = default;
+        virtual ~IIPparser() = default;
     };
 };
 

--- a/src/core/IIPparser.h
+++ b/src/core/IIPparser.h
@@ -15,6 +15,6 @@ namespace core{
     protected:
         IIPparser& operator=(const IIPparser&) = default;
     };
-}
+};
 
 #endif // IIPPARSER_H

--- a/src/core/IPaddressBase.cpp
+++ b/src/core/IPaddressBase.cpp
@@ -13,7 +13,7 @@ namespace core {
     IPaddressBase IPaddressBase::operator& (const IPaddressBase& var) const
     {
         return (this->_IpAddress & var._IpAddress);
-    }
+    };
 
     std::istream& operator>>(std::istream& in, IPaddressBase& b)
     {
@@ -35,7 +35,7 @@ namespace core {
         else throw NotImplemented{}; //TODO: error handling
 
         return  in;
-    }
+    };
 
     QString IPaddressBase::asStringDec() const
     {
@@ -46,7 +46,7 @@ namespace core {
         else throw NotImplemented{}; //TODO: error handling
 
         return tempAddress.to_string().c_str();
-    }
+    };
 
     QString IPaddressBase::asStringBin() const
     {
@@ -60,20 +60,20 @@ namespace core {
         }
         else if(_IpAddress.size() == 128) throw NotImplemented{"Printing ipv6 is not implemented"};
         else throw NotImplemented{}; //TODO: error handling
-    }
+    };
 
     bool IPaddressBase::operator==(const IPaddressBase& x) const
     {
         return this->_IpAddress == x._IpAddress;
-    }
+    };
 
     IPaddressBase IPaddressBase::operator| (const IPaddressBase& var) const
     {
         return (this->_IpAddress | var._IpAddress);
-    }
+    };
 
     bool IPaddressBase::operator!=(const IPaddressBase& x) const
     {
         return this->_IpAddress != x._IpAddress;
-    }
-}
+    };
+};

--- a/src/core/IPaddressBase.h
+++ b/src/core/IPaddressBase.h
@@ -3,27 +3,30 @@
 #define IPADDRESSBASE_H
 
 #include <boost/dynamic_bitset.hpp>
-#include <iostream>
-#include <QString>
+#include <memory>
+#include <istream>
 
 #include "IIPaddress.h"
 
 namespace core {
-    class IPaddressBase: public IIPaddress
+    class IPmaskBase; //forward declaration
+
+    class IPaddressBase : public virtual IIPaddress
     {
     public:
         IPaddressBase(const boost::dynamic_bitset<>& ipaddress): _IpAddress{ipaddress} {};
 
-        QString asStringDec() const final;
-        QString asStringBin() const final;
-
-        IPaddressBase operator& (const IPaddressBase& var) const;
-        IPaddressBase operator| (const IPaddressBase& var) const;
+        friend std::shared_ptr<IPaddressBase> operator&(const std::shared_ptr<IPaddressBase>& ip, const std::shared_ptr<IPmaskBase>& mask);
         bool operator==(const IPaddressBase&) const;
         bool operator!=(const IPaddressBase&) const;
 
-        friend std::istream& operator>>(std::istream&, IPaddressBase&);
+
+        friend std::istream& operator>>(std::istream&, std::shared_ptr<IPaddressBase>&);
+
+        virtual ~IPaddressBase() = default;
     protected:
+        virtual std::shared_ptr<IPaddressBase> _applyMask(const boost::dynamic_bitset<>& maskBitset) const = 0;
+
         boost::dynamic_bitset<> _IpAddress;
     };
 };

--- a/src/core/IPaddressBase.h
+++ b/src/core/IPaddressBase.h
@@ -26,8 +26,6 @@ namespace core {
     protected:
         boost::dynamic_bitset<> _IpAddress;
     };
-
-
-}
+};
 
 #endif // IPADDRESSBASE_H

--- a/src/core/IPmaskBase.cpp
+++ b/src/core/IPmaskBase.cpp
@@ -1,5 +1,15 @@
 #include "IPmaskBase.h"
 
+#include <boost/dynamic_bitset.hpp>
+#include <stdexcept>
+#include <istream>
+#include <memory>
+#include <string>
+
+#include "IPv4parser.h"
+#include "IPv4mask.h"
+#include "coreUtils.h"
+
 namespace core{
     IPmaskBase::IPmaskBase(const boost::dynamic_bitset<> &maskAddress): IPaddressBase{maskAddress}
     {
@@ -20,5 +30,20 @@ namespace core{
     short IPmaskBase::getPrefix() const
     {
         return static_cast<short>(_IpAddress.count());
+    };
+
+    std::istream& operator>>(std::istream& in, std::shared_ptr<IPmaskBase>& b)
+    {
+        std::string tempS;
+        in >> tempS;
+
+        if(dynamic_cast<IPv4mask*>(&*b))
+        {
+            b = IPv4parser{}.ipMaskFromString(tempS.c_str());
+        }
+        //else if(dynamic_cast<IPv6mask*>(&*b))
+        else throw NotImplemented{}; //TODO: error handling
+
+        return in;
     };
 };

--- a/src/core/IPmaskBase.cpp
+++ b/src/core/IPmaskBase.cpp
@@ -1,6 +1,22 @@
 #include "IPmaskBase.h"
 
 namespace core{
+    IPmaskBase::IPmaskBase(const boost::dynamic_bitset<> &maskAddress): IPaddressBase{maskAddress}
+    {
+        boost::dynamic_bitset<> bits(maskAddress.size());
+        bits.set();
+        if(maskAddress == bits) return;
+        else
+        {
+            for(size_t i = 0; i != bits.size(); ++i)
+            {
+                bits.flip(i);
+                if(maskAddress == bits) return;
+            }
+        }
+        throw std::invalid_argument("IP is not a mask");
+    }
+
     short IPmaskBase::getPrefix() const
     {
         return _IpAddress.count();

--- a/src/core/IPmaskBase.cpp
+++ b/src/core/IPmaskBase.cpp
@@ -19,6 +19,6 @@ namespace core{
 
     short IPmaskBase::getPrefix() const
     {
-        return _IpAddress.count();
+        return static_cast<short>(_IpAddress.count());
     };
 };

--- a/src/core/IPmaskBase.cpp
+++ b/src/core/IPmaskBase.cpp
@@ -12,13 +12,13 @@ namespace core{
             {
                 bits.flip(i);
                 if(maskAddress == bits) return;
-            }
-        }
+            };
+        };
         throw std::invalid_argument("IP is not a mask");
-    }
+    };
 
     short IPmaskBase::getPrefix() const
     {
         return _IpAddress.count();
-    }
-}
+    };
+};

--- a/src/core/IPmaskBase.h
+++ b/src/core/IPmaskBase.h
@@ -11,5 +11,6 @@ namespace core {
         IPmaskBase(const boost::dynamic_bitset<>& maskAddress);
         short getPrefix() const;
     };
-}
+};
+
 #endif // IPMASK_H

--- a/src/core/IPmaskBase.h
+++ b/src/core/IPmaskBase.h
@@ -3,13 +3,19 @@
 #define IPMASK_H
 
 #include "IPaddressBase.h"
+#include "IIPmask.h"
 
 namespace core {
-    class IPmaskBase : public IPaddressBase
+    class IPmaskBase : public virtual IPaddressBase, public IIPmask
     {
     public:
         IPmaskBase(const boost::dynamic_bitset<>& maskAddress);
-        short getPrefix() const;
+
+        short getPrefix() const final;
+
+        friend std::istream& operator>>(std::istream&, std::shared_ptr<IPmaskBase>&);
+
+        virtual ~IPmaskBase() = default;
     };
 };
 

--- a/src/core/IPmaskBase.h
+++ b/src/core/IPmaskBase.h
@@ -8,7 +8,7 @@ namespace core {
     class IPmaskBase : public IPaddressBase
     {
     public:
-        IPmaskBase(const boost::dynamic_bitset<>& maskAddress): IPaddressBase{maskAddress} {};
+        IPmaskBase(const boost::dynamic_bitset<>& maskAddress);
         short getPrefix() const;
     };
 }

--- a/src/core/IPstructs.h
+++ b/src/core/IPstructs.h
@@ -28,6 +28,6 @@ namespace core {
     {
         Subnetv4() { Ip = std::make_shared<IPv4address>(); NetMask = std::make_shared<IPv4mask>(); };
     };
-}
+};
 
 #endif // IPSTRUCTS_H

--- a/src/core/IPv4address.cpp
+++ b/src/core/IPv4address.cpp
@@ -1,0 +1,35 @@
+#include "IPv4address.h"
+
+#include <QString>
+#include <boost/asio/ip/address.hpp>
+#include <boost/dynamic_bitset.hpp>
+#include <string>
+#include <memory>
+
+namespace core {
+    QString IPv4address::asStringDec() const
+    {
+        return boost::asio::ip::make_address_v4(_IpAddress.to_ulong()).to_string().c_str();
+    };
+
+    QString IPv4address::asStringBin() const
+    {
+        std::string stringBinary;
+        boost::to_string(_IpAddress, stringBinary);
+
+        for(short i = 8; i <= 26; i += 9)
+            stringBinary.insert(stringBinary.begin()+ i, '.');
+
+        return stringBinary.c_str();
+    };
+
+    IPv4address IPv4address::operator|(const IPv4address &var) const
+    {
+        return (this->_IpAddress | var._IpAddress);
+    }
+
+    std::shared_ptr<IPaddressBase> IPv4address::_applyMask(const boost::dynamic_bitset<>& maskBitset) const
+    {
+        return std::make_shared<IPv4address>(this->_IpAddress & maskBitset);
+    };
+};

--- a/src/core/IPv4address.h
+++ b/src/core/IPv4address.h
@@ -3,15 +3,24 @@
 #define IPV4ADDRESS_H
 
 #include <boost/dynamic_bitset.hpp>
+#include <QString>
 
 #include "IPaddressBase.h"
 
 namespace core{
-    class IPv4address: public IPaddressBase
+    class IPv4address: public virtual IPaddressBase
     {
     public:
         IPv4address(): IPaddressBase(boost::dynamic_bitset<>(32)) {};
         IPv4address(const boost::dynamic_bitset<>& ipaddress): IPaddressBase(ipaddress) {};
+
+        QString asStringDec() const override;
+        QString asStringBin() const override;
+
+        IPv4address operator| (const IPv4address& var) const;
+
+    protected:
+        std::shared_ptr<IPaddressBase> _applyMask(const boost::dynamic_bitset<>& maskBitset) const override;
     };
 };
 

--- a/src/core/IPv4address.h
+++ b/src/core/IPv4address.h
@@ -13,6 +13,6 @@ namespace core{
         IPv4address(): IPaddressBase(boost::dynamic_bitset<>(32)) {};
         IPv4address(const boost::dynamic_bitset<>& ipaddress): IPaddressBase(ipaddress) {};
     };
-}
+};
 
 #endif // IPV4ADDRESS_H

--- a/src/core/IPv4mask.cpp
+++ b/src/core/IPv4mask.cpp
@@ -1,24 +1,10 @@
 #include "IPv4mask.h"
 
-#include <exception>
 #include <boost/dynamic_bitset.hpp>
 
 #include "IPmaskBase.h"
 
 namespace core {
     IPv4mask::IPv4mask(const boost::dynamic_bitset<>& maskAddress): IPmaskBase{maskAddress}
-    {
-        boost::dynamic_bitset<> bits(32);
-        bits.set(); //255.255.255.255
-        if(maskAddress == bits) return;
-        else
-        {
-            for(size_t i = 0; i != bits.size(); ++i)
-            {
-                bits.flip(i);
-                if(maskAddress == bits) return;
-            }
-        }
-        throw std::invalid_argument("IP is not a mask");
-    }
+    {}
 }

--- a/src/core/IPv4mask.cpp
+++ b/src/core/IPv4mask.cpp
@@ -6,5 +6,5 @@
 
 namespace core {
     IPv4mask::IPv4mask(const boost::dynamic_bitset<>& maskAddress): IPmaskBase{maskAddress}
-    {}
-}
+    {};
+};

--- a/src/core/IPv4mask.cpp
+++ b/src/core/IPv4mask.cpp
@@ -2,9 +2,7 @@
 
 #include <boost/dynamic_bitset.hpp>
 
-#include "IPmaskBase.h"
-
 namespace core {
-    IPv4mask::IPv4mask(const boost::dynamic_bitset<>& maskAddress): IPmaskBase{maskAddress}
-    {};
+    IPv4mask::IPv4mask(const boost::dynamic_bitset<>& maskAddress): IPaddressBase{maskAddress}, IPmaskBase{maskAddress}
+        {};
 };

--- a/src/core/IPv4mask.h
+++ b/src/core/IPv4mask.h
@@ -13,6 +13,6 @@ namespace core {
         IPv4mask() : IPmaskBase(boost::dynamic_bitset<>(32)) {};
         IPv4mask(const boost::dynamic_bitset<>& maskAddress);
     };
-}
+};
 
 #endif // IIPMASK_H

--- a/src/core/IPv4mask.h
+++ b/src/core/IPv4mask.h
@@ -1,18 +1,25 @@
 #pragma once
-#ifndef IIPMASK_H
-#define IIPMASK_H
+#ifndef IPv4MASK_H
+#define IPv4MASK_H
 
 #include <boost/dynamic_bitset.hpp>
 
+#include "IPv4address.h"
 #include "IPmaskBase.h"
 
 namespace core {
-    class IPv4mask final: public IPmaskBase
+    class IPv4mask final: public IPv4address, public IPmaskBase
     {
     public:
-        IPv4mask() : IPmaskBase(boost::dynamic_bitset<>(32)) {};
+        IPv4mask() : IPaddressBase(boost::dynamic_bitset<>(32)), IPmaskBase(boost::dynamic_bitset<>(32)) {};
         IPv4mask(const boost::dynamic_bitset<>& maskAddress);
+
+        QString asStringBin() const override { return IPv4address::asStringBin(); };
+        QString asStringDec() const override { return IPv4address::asStringDec(); };
+
+    private:
+        std::shared_ptr<IPaddressBase> _applyMask(const boost::dynamic_bitset<>& maskBitset) const override { return IPv4address::_applyMask(maskBitset); };
     };
 };
 
-#endif // IIPMASK_H
+#endif // IPv4MASK_H

--- a/src/core/IPv4parser.cpp
+++ b/src/core/IPv4parser.cpp
@@ -1,0 +1,33 @@
+#include "IPv4parser.h"
+
+#include <QString>
+#include <memory>
+#include <stdexcept>
+#include <boost/dynamic_bitset.hpp>
+#include <boost/asio/ip/address_v4.hpp>
+#include <string>
+
+#include "IPv4address.h"
+#include "IPv4mask.h"
+
+namespace core {
+    std::shared_ptr<IPaddressBase> IPv4parser::ipFromString(const QString& IP) const
+    {
+        return std::make_shared<IPv4address>(_getBitset(IP.toStdString()));
+    }
+
+    std::shared_ptr<IPmaskBase> IPv4parser::ipMaskFromString(const QString & mask) const
+    {
+        return std::make_shared<IPv4mask>(_getBitset(mask.toStdString()));
+    }
+
+    boost::dynamic_bitset<> IPv4parser::_getBitset(const std::string& addressString) const
+    {
+        try {
+            auto v4address = boost::asio::ip::make_address_v4(addressString);
+            return boost::dynamic_bitset<> (32, v4address.to_ulong());
+        } catch (const boost::system::system_error&) {
+            std::throw_with_nested(std::runtime_error("Wrong input IP address"));
+        };
+    };
+};

--- a/src/core/IPv4parser.h
+++ b/src/core/IPv4parser.h
@@ -29,11 +29,11 @@ namespace core{
             converted = boost::asio::ip::make_address_v4(IP.toStdString());
         } catch (const boost::system::system_error&) {
             std::throw_with_nested(std::runtime_error("Wrong input IP address"));
-        }
+        };
 
         boost::dynamic_bitset<> octetContainer(32, converted.to_ulong());
         return std::move(octetContainer);
-    }
-}
+    };
+};
 
 #endif // IPV4PARSER_H

--- a/src/core/IPv4parser.h
+++ b/src/core/IPv4parser.h
@@ -4,35 +4,19 @@
 
 #include <QString>
 #include <memory>
-#include <exception>
 #include <boost/dynamic_bitset.hpp>
-#include <boost/asio/ip/address_v4.hpp>
+#include <string>
 
 #include "IIPparser.h"
 
 namespace core{
-    class IPv4address; //forward declaration
-
-    template <class C = IPv4address>
-    class IPv4parser final: public IIPparser<C>
+    class IPv4parser final: public IIPparser
     {
     public:
-        C ipFromString(const QString&) const final;
-    };
-
-    template <class C>
-    C IPv4parser<C>::ipFromString(const QString& IP) const
-    {
-        boost::asio::ip::address_v4 converted;
-
-        try {
-            converted = boost::asio::ip::make_address_v4(IP.toStdString());
-        } catch (const boost::system::system_error&) {
-            std::throw_with_nested(std::runtime_error("Wrong input IP address"));
-        };
-
-        boost::dynamic_bitset<> octetContainer(32, converted.to_ulong());
-        return std::move(octetContainer);
+        std::shared_ptr<IPaddressBase> ipFromString(const QString &) const final;
+        std::shared_ptr<IPmaskBase> ipMaskFromString(const QString &) const final;
+    private:
+        boost::dynamic_bitset<> _getBitset(const std::string& addressString) const;
     };
 };
 

--- a/src/core/SubnetsCalculatorV4.cpp
+++ b/src/core/SubnetsCalculatorV4.cpp
@@ -25,10 +25,10 @@ namespace core {
             auto Address = _chooseSubnetIP(*mainNet.Ip, Mask, _subNets); //TODO: error handling
             *_subNet->Ip = Address;
             *_subNet->NetMask = Mask;
-        }
+        };
         //end of specific v4 implementation
         return 0;
-    }
+    };
 
     IPmaskBase SubnetsCalculatorV4::_chooseSubnetMask(const long long& desiredHostsNumber)
     {
@@ -39,10 +39,10 @@ namespace core {
         {
             countHosts = std::pow(2, numberOfHostBits);
             numberOfHostBits++;
-        }
+        };
 
         return boost::dynamic_bitset<>(32, 4294967295 - (countHosts - 1));
-    }
+    };
 
     IPaddressBase SubnetsCalculatorV4::_chooseSubnetIP(const IPaddressBase& mainNetIP, const IPmaskBase& Mask, const std::vector<std::shared_ptr<Subnet>>& alreadyAssignedIPs)
     {
@@ -56,7 +56,7 @@ namespace core {
             IPv4address NetWildCard{create};
             pretenderAddress = mainNetIP | NetWildCard;
             netBits++;
-        }
+        };
         return pretenderAddress;
-    }
-}
+    };
+};

--- a/src/core/SubnetsCalculatorV4.cpp
+++ b/src/core/SubnetsCalculatorV4.cpp
@@ -2,8 +2,12 @@
 
 #include <algorithm>
 #include <boost/dynamic_bitset.hpp>
+#include <vector>
+#include <memory>
+#include <cmath>
 
 #include "coreUtils.h"
+#include "IIPmask.h"
 
 namespace core {
     int SubnetsCalculatorV4::calcSubnets(const NetworkBase& mainNet, const std::vector<std::shared_ptr<Subnet>>& subNets)
@@ -22,15 +26,15 @@ namespace core {
         for(const auto& _subNet : _subNets)
         {
             auto Mask = _chooseSubnetMask(_subNet->HostNumber); //TODO: error handling when choosen mask exceeds main mask, check if such situation's even possible
-            auto Address = _chooseSubnetIP(*mainNet.Ip, Mask, _subNets); //TODO: error handling
-            *_subNet->Ip = Address;
-            *_subNet->NetMask = Mask;
+            auto Address = _chooseSubnetIP(*mainNet.Ip, *Mask, _subNets); //TODO: error handling
+            _subNet->Ip = Address;
+            _subNet->NetMask = Mask;
         };
         //end of specific v4 implementation
         return 0;
     };
 
-    IPmaskBase SubnetsCalculatorV4::_chooseSubnetMask(const long long& desiredHostsNumber)
+    std::shared_ptr<IPmaskBase> SubnetsCalculatorV4::_chooseSubnetMask(const long long& desiredHostsNumber)
     {
         unsigned short numberOfHostBits = 1;
         long long int countHosts = 0;
@@ -41,22 +45,24 @@ namespace core {
             numberOfHostBits++;
         };
 
-        return boost::dynamic_bitset<>(32, 4294967295 - (countHosts - 1));
+        return std::make_shared<IPv4mask>(boost::dynamic_bitset<>(32, 4294967295 - (countHosts - 1)));
     };
 
-    IPaddressBase SubnetsCalculatorV4::_chooseSubnetIP(const IPaddressBase& mainNetIP, const IPmaskBase& Mask, const std::vector<std::shared_ptr<Subnet>>& alreadyAssignedIPs)
+    std::shared_ptr<IPaddressBase> SubnetsCalculatorV4::_chooseSubnetIP(const IPaddressBase& mainNetIP, const IIPmask& Mask, const std::vector<std::shared_ptr<Subnet>>& alreadyAssignedIPs)
     {
-        IPaddressBase pretenderAddress{mainNetIP};
+        auto pretenderAddress{*dynamic_cast<const IPv4address*>(&mainNetIP)};
+
         unsigned long long int netBits = 1;
 
         while(std::any_of(alreadyAssignedIPs.begin(), alreadyAssignedIPs.end(), [&](const auto& x){
                        return *x->Ip == pretenderAddress;}))
         {
             auto create = boost::dynamic_bitset<>(32, netBits << (32 - Mask.getPrefix()));
+
             IPv4address NetWildCard{create};
-            pretenderAddress = mainNetIP | NetWildCard;
+            pretenderAddress = *dynamic_cast<const IPv4address*>(&mainNetIP) | NetWildCard;
             netBits++;
         };
-        return pretenderAddress;
+        return std::make_shared<IPv4address>(pretenderAddress);
     };
 };

--- a/src/core/SubnetsCalculatorV4.cpp
+++ b/src/core/SubnetsCalculatorV4.cpp
@@ -10,7 +10,7 @@ namespace core {
     {
         auto _subNets = subNets;
 
-        std::sort(_subNets.begin(), _subNets.end(),[](const std::shared_ptr<Subnet>& a, const std::shared_ptr<Subnet>& b){
+        std::sort(_subNets.begin(), _subNets.end(),[](const auto& a, const auto& b){
             return a->HostNumber > b->HostNumber;
         });
 
@@ -49,7 +49,7 @@ namespace core {
         IPaddressBase pretenderAddress{mainNetIP};
         unsigned long long int netBits = 1;
 
-        while(std::any_of(alreadyAssignedIPs.begin(), alreadyAssignedIPs.end(), [&](const std::shared_ptr<Subnet>& x){
+        while(std::any_of(alreadyAssignedIPs.begin(), alreadyAssignedIPs.end(), [&](const auto& x){
                        return *x->Ip == pretenderAddress;}))
         {
             auto create = boost::dynamic_bitset<>(32, netBits << (32 - Mask.getPrefix()));

--- a/src/core/SubnetsCalculatorV4.h
+++ b/src/core/SubnetsCalculatorV4.h
@@ -8,13 +8,15 @@
 #include "IPstructs.h"
 
 namespace core {
+    class IIPmask; //forward declaration
+
     class SubnetsCalculatorV4
     {
     public:
         int calcSubnets(const NetworkBase& mainNet, const std::vector<std::shared_ptr<Subnet>>& subNets);
     private:
-        IPmaskBase _chooseSubnetMask(const long long& desiredHostsNumber);
-        IPaddressBase _chooseSubnetIP(const IPaddressBase& mainNetIP, const IPmaskBase& pretentMask, const std::vector<std::shared_ptr<Subnet>>& alreadyAssignedIPs);
+        std::shared_ptr<IPmaskBase> _chooseSubnetMask(const long long& desiredHostsNumber);
+        std::shared_ptr<IPaddressBase> _chooseSubnetIP(const IPaddressBase& mainNetIP, const IIPmask& Mask, const std::vector<std::shared_ptr<Subnet>>& alreadyAssignedIPs);
     };
 };
 

--- a/src/core/SubnetsCalculatorV4.h
+++ b/src/core/SubnetsCalculatorV4.h
@@ -16,6 +16,6 @@ namespace core {
         IPmaskBase _chooseSubnetMask(const long long& desiredHostsNumber);
         IPaddressBase _chooseSubnetIP(const IPaddressBase& mainNetIP, const IPmaskBase& pretentMask, const std::vector<std::shared_ptr<Subnet>>& alreadyAssignedIPs);
     };
-}
+};
 
 #endif // SUBNETSCALCULATORV4_H

--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -7,13 +7,16 @@ include(../../common.pri)
 
 SOURCES += \
     IPaddressBase.cpp \
+    IPv4address.cpp \
     IPv4mask.cpp \
+    IPv4parser.cpp \
     SubnetsCalculatorV4.cpp \
     IPmaskBase.cpp \
     coreUtils.cpp
 
 HEADERS += \
     IIPaddress.h \
+    IIPmask.h \
     IIPparser.h \
     IPaddressBase.h \
     IPmaskBase.h \

--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -9,7 +9,8 @@ SOURCES += \
     IPaddressBase.cpp \
     IPv4mask.cpp \
     SubnetsCalculatorV4.cpp \
-    IPmaskBase.cpp
+    IPmaskBase.cpp \
+    coreUtils.cpp
 
 HEADERS += \
     IIPaddress.h \

--- a/src/core/coreUtils.cpp
+++ b/src/core/coreUtils.cpp
@@ -1,0 +1,23 @@
+#include "coreUtils.h"
+
+#include "IIPaddress.h"
+
+namespace core {
+    const char* NotImplemented::what() const throw()
+    {
+        return _text.c_str();
+    };
+
+    NotImplemented::NotImplemented(const char *message, const char *function) : std::logic_error("Not Implemented")
+    {
+        _text = message;
+        _text += " : ";
+        _text += function;
+    };
+
+    std::ostream& operator<< (std::ostream& out, const IIPaddress& c)
+    {
+        out << c.asStringDec().toStdString() << std::flush;
+        return out;
+    };
+};

--- a/src/core/coreUtils.h
+++ b/src/core/coreUtils.h
@@ -2,11 +2,12 @@
 #ifndef COREUTILS_H
 #define COREUTILS_H
 
-#include <exception>
+#include <stdexcept>
 #include <string>
 
 namespace core {
     class IIPaddress; //forward declaration
+
     class NotImplemented : public std::logic_error
     {
     public:

--- a/src/core/coreUtils.h
+++ b/src/core/coreUtils.h
@@ -6,27 +6,22 @@
 #include <string>
 
 namespace core {
+    class IIPaddress; //forward declaration
     class NotImplemented : public std::logic_error
     {
     public:
-
         NotImplemented(): NotImplemented("Not Implememented", __FUNCTION__) {};
         NotImplemented(const char* message): NotImplemented(message, __FUNCTION__) {};
 
-        virtual const char *what() const throw()
-        {
-            return _text.c_str();
-        }
+        virtual const char *what() const throw();
+
     private:
         std::string _text;
 
-        NotImplemented(const char* message, const char* function): std::logic_error("Not Implemented")
-        {
-            _text = message;
-            _text += " : ";
-            _text += function;
-        };
+        NotImplemented(const char* message, const char* function);
     };
-}
+
+    std::ostream& operator<< (std::ostream& out, const IIPaddress& c);
+};
 
 #endif // COREUTILS_H

--- a/tests/IPaddressBaseTests.cpp
+++ b/tests/IPaddressBaseTests.cpp
@@ -1,0 +1,40 @@
+#include <catch2/catch.hpp>
+#include <boost/dynamic_bitset.hpp>
+
+#include "IPaddressBase.h"
+
+using namespace core;
+
+namespace IPaddressBaseTests {
+    TEST_CASE("IPaddressBase Tests"){
+        const boost::dynamic_bitset <> bitset_ip {32, 3232235521} //192.168.0.1
+        , bitset_mask1 {32, 4294967040} //255.255.255.0
+        , bitset_mask2 {32, 4293918720}; //255.240.0.0
+
+        const IPaddressBase ip4address {bitset_ip};
+        const IPaddressBase mask1 {bitset_mask1};
+        const IPaddressBase mask2 {bitset_mask2};
+
+        SECTION("asStringDec conversion"){
+            REQUIRE(ip4address.asStringDec() == "192.168.0.1");
+            REQUIRE(mask2.asStringDec() == "255.240.0.0");
+        };
+        SECTION("asStringBin conversion"){
+            REQUIRE(ip4address.asStringBin() == "11000000.10101000.00000000.00000001");
+            REQUIRE(mask2.asStringBin() == "11111111.11110000.00000000.00000000");
+        };
+        SECTION("AND operation wit IP and mask"){
+            IPaddressBase expected = ip4address & mask1;
+            CHECK(expected.asStringDec() == "192.168.0.0");
+            expected = ip4address & mask2;
+            CHECK(expected.asStringDec() == "192.160.0.0");
+        };
+        SECTION("operator =="){
+            const IPaddressBase compareME{bitset_ip};
+            CHECK(ip4address == compareME);
+        };
+        SECTION("operator !="){
+            CHECK(mask1 != mask2);
+        };
+    };
+};

--- a/tests/IPaddressBaseTests.cpp
+++ b/tests/IPaddressBaseTests.cpp
@@ -16,12 +16,12 @@ namespace IPaddressBaseTests {
         const IPaddressBase mask2 {bitset_mask2};
 
         SECTION("asStringDec conversion"){
-            REQUIRE(ip4address.asStringDec() == "192.168.0.1");
-            REQUIRE(mask2.asStringDec() == "255.240.0.0");
+            CHECK(ip4address.asStringDec() == "192.168.0.1");
+            CHECK(mask2.asStringDec() == "255.240.0.0");
         };
         SECTION("asStringBin conversion"){
-            REQUIRE(ip4address.asStringBin() == "11000000.10101000.00000000.00000001");
-            REQUIRE(mask2.asStringBin() == "11111111.11110000.00000000.00000000");
+            CHECK(ip4address.asStringBin() == "11000000.10101000.00000000.00000001");
+            CHECK(mask2.asStringBin() == "11111111.11110000.00000000.00000000");
         };
         SECTION("AND operation wit IP and mask"){
             IPaddressBase expected = ip4address & mask1;

--- a/tests/IPv4addressTests.cpp
+++ b/tests/IPv4addressTests.cpp
@@ -1,19 +1,20 @@
 #include <catch2/catch.hpp>
 #include <boost/dynamic_bitset.hpp>
 
-#include "IPaddressBase.h"
+#include "IPv4address.h"
+#include "IPv4mask.h"
 
 using namespace core;
 
-namespace IPaddressBaseTests {
-    TEST_CASE("IPaddressBase Tests"){
+namespace IPv4addressTests {
+    TEST_CASE("IPv4address Tests"){
         const boost::dynamic_bitset <> bitset_ip {32, 3232235521} //192.168.0.1
         , bitset_mask1 {32, 4294967040} //255.255.255.0
         , bitset_mask2 {32, 4293918720}; //255.240.0.0
 
-        const IPaddressBase ip4address {bitset_ip};
-        const IPaddressBase mask1 {bitset_mask1};
-        const IPaddressBase mask2 {bitset_mask2};
+        const IPv4address ip4address {bitset_ip};
+        const IPv4address mask1 {bitset_mask1};
+        const IPv4address mask2 {bitset_mask2};
 
         SECTION("asStringDec conversion"){
             CHECK(ip4address.asStringDec() == "192.168.0.1");
@@ -24,13 +25,21 @@ namespace IPaddressBaseTests {
             CHECK(mask2.asStringBin() == "11111111.11110000.00000000.00000000");
         };
         SECTION("AND operation wit IP and mask"){
-            IPaddressBase expected = ip4address & mask1;
-            CHECK(expected.asStringDec() == "192.168.0.0");
-            expected = ip4address & mask2;
-            CHECK(expected.asStringDec() == "192.160.0.0");
+            const IPv4mask mask1 {bitset_mask1};
+            const IPv4mask mask2 {bitset_mask2};
+
+            std::shared_ptr<IPaddressBase> left = std::make_shared<IPv4address>(ip4address);
+            std::shared_ptr<IPmaskBase> right = std::make_shared<IPv4mask>(mask1);
+
+            auto expected = left & right;
+            CHECK(expected->asStringDec() == "192.168.0.0");
+
+            right = std::make_shared<IPv4mask>(mask2);
+            expected = left & right;
+            CHECK(expected->asStringDec() == "192.160.0.0");
         };
         SECTION("operator =="){
-            const IPaddressBase compareME{bitset_ip};
+            IPv4address compareME{bitset_ip};
             CHECK(ip4address == compareME);
         };
         SECTION("operator !="){

--- a/tests/IPv4maskTests.cpp
+++ b/tests/IPv4maskTests.cpp
@@ -32,5 +32,9 @@ namespace IPv4maskTests {
                 CHECK_THROWS_AS(IPv4mask{bitset_ip}, std::invalid_argument);
             };
         };
+        SECTION("Get proper ipv4 prefix"){
+            CHECK(IPv4mask().getPrefix() == 0);
+            CHECK(IPv4mask(boost::dynamic_bitset<> {32, 4294967295}).getPrefix() == 32); //255.255.255.255
+        };
     };
 };

--- a/tests/IPv4maskTests.cpp
+++ b/tests/IPv4maskTests.cpp
@@ -22,14 +22,14 @@ namespace IPv4maskTests {
                 std::string temps;
                 to_string(element, temps);
                 THEN(std::string("Object created: ") + temps){
-                    REQUIRE_NOTHROW(IPv4mask{element});
+                    CHECK_NOTHROW(IPv4mask{element});
                 };
             };
         };
         WHEN("Mask is invalid format"){
             boost::dynamic_bitset<> bitset_ip{32, 3232235521}; //192.168.0.1
             THEN("Ctor throws error"){
-                REQUIRE_THROWS_AS(IPv4mask{bitset_ip}, std::invalid_argument);
+                CHECK_THROWS_AS(IPv4mask{bitset_ip}, std::invalid_argument);
             };
         };
     };

--- a/tests/IPv4maskTests.cpp
+++ b/tests/IPv4maskTests.cpp
@@ -1,0 +1,36 @@
+#include <catch2/catch.hpp>
+#include <boost/dynamic_bitset.hpp>
+#include <vector>
+#include <string>
+#include <exception>
+
+#include "IPv4mask.h"
+
+using namespace core;
+
+namespace IPv4maskTests {
+    TEST_CASE("IPv4mask Tests"){
+        WHEN("Mask is valid format"){
+            const std::vector<boost::dynamic_bitset<>> bitsets {
+            boost::dynamic_bitset<> {32, 4294967295} //255.255.255.255
+            , boost::dynamic_bitset<> {32, 2147483648} //128.0.0.0
+            , boost::dynamic_bitset<> {32, 0} //0.0.0.0
+            };
+
+            for(const auto& element : bitsets)
+            {
+                std::string temps;
+                to_string(element, temps);
+                THEN(std::string("Object created: ") + temps){
+                    REQUIRE_NOTHROW(IPv4mask{element});
+                };
+            };
+        };
+        WHEN("Mask is invalid format"){
+            boost::dynamic_bitset<> bitset_ip{32, 3232235521}; //192.168.0.1
+            THEN("Ctor throws error"){
+                REQUIRE_THROWS_AS(IPv4mask{bitset_ip}, std::invalid_argument);
+            };
+        };
+    };
+};

--- a/tests/IPv4maskTests.cpp
+++ b/tests/IPv4maskTests.cpp
@@ -2,7 +2,7 @@
 #include <boost/dynamic_bitset.hpp>
 #include <vector>
 #include <string>
-#include <exception>
+#include <stdexcept>
 
 #include "IPv4mask.h"
 

--- a/tests/IPv4parserTests.cpp
+++ b/tests/IPv4parserTests.cpp
@@ -1,8 +1,7 @@
 #include <catch2/catch.hpp>
-#include <exception>
+#include <stdexcept>
 #include <boost/dynamic_bitset.hpp>
 
-#include "IPv4address.h"
 #include "IPv4parser.h"
 
 using namespace core;
@@ -14,11 +13,21 @@ namespace IPv4parserTest {
         SECTION("Parsing string with valid ip address into IP object"){
             CHECK_NOTHROW(ip4parser.ipFromString("192.168.0.1"));
         };
-        SECTION("Parsing string with invalid ip address into IP object"){
+        SECTION("Parsing string with invalid ip address"){
             CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.256"), std::nested_exception);
             CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.255/21"), std::nested_exception);
             CHECK_THROWS_AS(ip4parser.ipFromString("foobar"), std::nested_exception);
             CHECK_THROWS_AS(ip4parser.ipFromString("fe80::1"), std::nested_exception);
+        };
+
+        SECTION("Parsing string with valid ip mask address into IPmask object"){
+            CHECK_NOTHROW(ip4parser.ipMaskFromString("255.255.255.128"));
+        };
+        SECTION("Parsing string with invalid ip mask address"){
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("255.256.0.0"), std::nested_exception);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("255.0.0.0/21"), std::nested_exception);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("foobar"), std::nested_exception);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("fe80::1"), std::nested_exception);
         };
     };
 };

--- a/tests/IPv4parserTests.cpp
+++ b/tests/IPv4parserTests.cpp
@@ -110,7 +110,7 @@ namespace IPv4parserTest {
             calculatedNetworks.emplace_back("192.168.0.48");
 
             for(const auto& var : calculatedNetworks)
-                CHECK(std::any_of(subs.begin(), subs.end(), [&var](std::shared_ptr<Subnet> x){
+                CHECK(std::any_of(subs.begin(), subs.end(), [&var](const auto& x){
                     return x->Ip->asStringDec() == var;
                 }));
         }

--- a/tests/IPv4parserTests.cpp
+++ b/tests/IPv4parserTests.cpp
@@ -1,12 +1,9 @@
 #include <catch2/catch.hpp>
 #include <exception>
 #include <boost/dynamic_bitset.hpp>
-#include <vector>
 
 #include "IPv4address.h"
 #include "IPv4parser.h"
-#include "IPv4mask.h"
-#include "SubnetsCalculatorV4.h"
 
 using namespace core;
 
@@ -16,103 +13,12 @@ namespace IPv4parserTest {
 
         SECTION("Parsing string with valid ip address into IP object"){
             REQUIRE_NOTHROW(ip4parser.ipFromString("192.168.0.1"));
-        }
+        };
         SECTION("Parsing string with invalid ip address into IP object"){
             REQUIRE_THROWS_AS(ip4parser.ipFromString("192.168.0.256"), std::nested_exception);
             REQUIRE_THROWS_AS(ip4parser.ipFromString("192.168.0.255/21"), std::nested_exception);
             REQUIRE_THROWS_AS(ip4parser.ipFromString("foobar"), std::nested_exception);
             REQUIRE_THROWS_AS(ip4parser.ipFromString("fe80::1"), std::nested_exception);
-        }
-    }
-
-    TEST_CASE("IPaddressBase Tests"){
-        const boost::dynamic_bitset <> bitset_ip {32, 3232235521} //192.168.0.1
-        , bitset_mask1 {32, 4294967040} //255.255.255.0
-        , bitset_mask2 {32, 4293918720}; //255.240.0.0
-
-        const IPaddressBase ip4address {bitset_ip};
-        const IPaddressBase mask1 {bitset_mask1};
-        const IPaddressBase mask2 {bitset_mask2};
-
-        SECTION("asStringDec conversion"){
-            REQUIRE(ip4address.asStringDec() == "192.168.0.1");
-            REQUIRE(mask2.asStringDec() == "255.240.0.0");
-        }
-        SECTION("asStringBin conversion"){
-            REQUIRE(ip4address.asStringBin() == "11000000.10101000.00000000.00000001");
-            REQUIRE(mask2.asStringBin() == "11111111.11110000.00000000.00000000");
-        }
-        SECTION("AND operation wit IP and mask"){
-            IPaddressBase expected = ip4address & mask1;
-            CHECK(expected.asStringDec() == "192.168.0.0");
-            expected = ip4address & mask2;
-            CHECK(expected.asStringDec() == "192.160.0.0");
-        }
-        SECTION("operator =="){
-            const IPaddressBase compareME{bitset_ip};
-            CHECK(ip4address == compareME);
-        }
-        SECTION("operator !="){
-            CHECK(mask1 != mask2);
-        }
-    }
-
-    TEST_CASE("IPv4mask Tests"){
-        WHEN("Mask is valid format"){
-            const std::vector<boost::dynamic_bitset<>> bitsets {
-            boost::dynamic_bitset<> {32, 4294967295} //255.255.255.255
-            , boost::dynamic_bitset<> {32, 2147483648} //128.0.0.0
-            , boost::dynamic_bitset<> {32, 0} //0.0.0.0
-            };
-
-            for(const auto& element : bitsets)
-            {
-                std::string temps;
-                to_string(element, temps);
-                THEN(std::string("Object created: ") + temps){
-                    REQUIRE_NOTHROW(IPv4mask{element});
-                }
-            }
-        }
-        WHEN("Mask is invalid format"){
-            boost::dynamic_bitset<> bitset_ip{32, 3232235521}; //192.168.0.1
-            THEN("Ctor throws error"){
-                REQUIRE_THROWS_AS(IPv4mask{bitset_ip}, std::invalid_argument);
-            }
-        }
-    }
-
-    TEST_CASE("SubnetsCalculatorV4 Tests"){
-        Networkv4 net;
-        std::vector<std::shared_ptr<Subnet>> subs;
-
-        SECTION("Subneting with constant mask length")
-        {
-            *net.Ip = IPv4address{boost::dynamic_bitset<>(32, 3232235520)}; //192.168.0.0
-            *net.NetMask = IPv4mask{boost::dynamic_bitset<>(32, 4294967232)}; //255.255.255.192 /26
-
-            for(unsigned short i = 0; i <= 4; i++)
-            {
-                subs.push_back(std::make_shared<Subnetv4>());
-                subs.back()->HostNumber = 10;
-            }
-
-            SubnetsCalculatorV4 calc;
-            calc.calcSubnets(net, subs);
-
-            for(const auto& sub : subs)
-                CHECK(sub->NetMask->asStringDec() == "255.255.255.240");
-
-            std::vector<QString> calculatedNetworks;
-            calculatedNetworks.emplace_back("192.168.0.0");
-            calculatedNetworks.emplace_back("192.168.0.16");
-            calculatedNetworks.emplace_back("192.168.0.32");
-            calculatedNetworks.emplace_back("192.168.0.48");
-
-            for(const auto& var : calculatedNetworks)
-                CHECK(std::any_of(subs.begin(), subs.end(), [&var](const auto& x){
-                    return x->Ip->asStringDec() == var;
-                }));
-        }
-    }
-}
+        };
+    };
+};

--- a/tests/IPv4parserTests.cpp
+++ b/tests/IPv4parserTests.cpp
@@ -12,13 +12,13 @@ namespace IPv4parserTest {
         const IPv4parser ip4parser;
 
         SECTION("Parsing string with valid ip address into IP object"){
-            REQUIRE_NOTHROW(ip4parser.ipFromString("192.168.0.1"));
+            CHECK_NOTHROW(ip4parser.ipFromString("192.168.0.1"));
         };
         SECTION("Parsing string with invalid ip address into IP object"){
-            REQUIRE_THROWS_AS(ip4parser.ipFromString("192.168.0.256"), std::nested_exception);
-            REQUIRE_THROWS_AS(ip4parser.ipFromString("192.168.0.255/21"), std::nested_exception);
-            REQUIRE_THROWS_AS(ip4parser.ipFromString("foobar"), std::nested_exception);
-            REQUIRE_THROWS_AS(ip4parser.ipFromString("fe80::1"), std::nested_exception);
+            CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.256"), std::nested_exception);
+            CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.255/21"), std::nested_exception);
+            CHECK_THROWS_AS(ip4parser.ipFromString("foobar"), std::nested_exception);
+            CHECK_THROWS_AS(ip4parser.ipFromString("fe80::1"), std::nested_exception);
         };
     };
 };

--- a/tests/SubnetsCalculatorV4Tests.cpp
+++ b/tests/SubnetsCalculatorV4Tests.cpp
@@ -13,7 +13,7 @@ namespace SubnetsCalculatorV4Tests {
         Networkv4 net;
         std::vector<std::shared_ptr<Subnet>> subs;
 
-        SECTION("Subneting with constant mask length")
+        SECTION("Subneting with the same number of hosts")
         {
             *net.Ip = IPv4address{boost::dynamic_bitset<>(32, 3232235520)}; //192.168.0.0
             *net.NetMask = IPv4mask{boost::dynamic_bitset<>(32, 4294967232)}; //255.255.255.192 /26
@@ -24,8 +24,11 @@ namespace SubnetsCalculatorV4Tests {
                 subs.back()->HostNumber = 10;
             };
 
+            auto subsCopy = subs;
             SubnetsCalculatorV4 calc;
             calc.calcSubnets(net, subs);
+
+            CHECK(subs == subsCopy); // calcSubnets shouldn't mix vector's order
 
             for(const auto& sub : subs)
                 CHECK(sub->NetMask->asStringDec() == "255.255.255.240");

--- a/tests/SubnetsCalculatorV4Tests.cpp
+++ b/tests/SubnetsCalculatorV4Tests.cpp
@@ -1,0 +1,45 @@
+#include <catch2/catch.hpp>
+#include <boost/dynamic_bitset.hpp>
+#include <vector>
+#include <memory>
+#include <algorithm>
+
+#include "SubnetsCalculatorV4.h"
+
+using namespace core;
+
+namespace SubnetsCalculatorV4Tests {
+    TEST_CASE("SubnetsCalculatorV4 Tests"){
+        Networkv4 net;
+        std::vector<std::shared_ptr<Subnet>> subs;
+
+        SECTION("Subneting with constant mask length")
+        {
+            *net.Ip = IPv4address{boost::dynamic_bitset<>(32, 3232235520)}; //192.168.0.0
+            *net.NetMask = IPv4mask{boost::dynamic_bitset<>(32, 4294967232)}; //255.255.255.192 /26
+
+            for(unsigned short i = 0; i <= 4; i++)
+            {
+                subs.push_back(std::make_shared<Subnetv4>());
+                subs.back()->HostNumber = 10;
+            };
+
+            SubnetsCalculatorV4 calc;
+            calc.calcSubnets(net, subs);
+
+            for(const auto& sub : subs)
+                CHECK(sub->NetMask->asStringDec() == "255.255.255.240");
+
+            std::vector<QString> calculatedNetworks;
+            calculatedNetworks.emplace_back("192.168.0.0");
+            calculatedNetworks.emplace_back("192.168.0.16");
+            calculatedNetworks.emplace_back("192.168.0.32");
+            calculatedNetworks.emplace_back("192.168.0.48");
+
+            for(const auto& var : calculatedNetworks)
+                CHECK(std::any_of(subs.begin(), subs.end(), [&var](const auto& x){
+                    return x->Ip->asStringDec() == var;
+                }));
+        };
+    };
+};

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -7,7 +7,7 @@ CONFIG += testcase
 include(../common.pri)
 
 SOURCES += \
-    IPaddressBaseTests.cpp \
+    IPv4addressTests.cpp \
     IPv4maskTests.cpp \
     IPv4parserTests.cpp \
     SubnetsCalculatorV4Tests.cpp \

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -7,7 +7,10 @@ CONFIG += testcase
 include(../common.pri)
 
 SOURCES += \
+    IPaddressBaseTests.cpp \
+    IPv4maskTests.cpp \
     IPv4parserTests.cpp \
+    SubnetsCalculatorV4Tests.cpp \
     main.cpp
 
 INCLUDEPATH += \


### PR DESCRIPTION
Aktualnie klasa parsera ma osobną metodę do tworzenia obiektu IPmaskBase, co rozwiązuje problem tworzenia obiektu klasy Networkv4 używając UI.