### PR TITLE
Unify error handling

### DIFF
--- a/src/console/main.cpp
+++ b/src/console/main.cpp
@@ -2,12 +2,12 @@
 #include <iostream>
 #include <vector>
 #include <memory>
+#include <QTextStream>
+#include <string>
 
 #include "IPstructs.h"
 #include "SubnetsCalculatorV4.h"
 #include "coreUtils.h"
-#include <QTextStream>
-#include <string>
 
 using namespace core;
 

--- a/src/console/main.cpp
+++ b/src/console/main.cpp
@@ -70,8 +70,11 @@ int main(int argc, char *argv[])
     for(const auto& sub : subnets)
     {
         std::cout << "\nNazwa podsieci: " << sub->SubName
-                  << " IP: " << *sub->Ip
-                  << " Maska: " << *sub->NetMask;
+                  << "\nIP: " << *sub->Ip
+                  << " Maska: " << *sub->NetMask
+                  << " Broadcast: " << *sub->getBroadcast()
+                  << "\nminHost: " << *sub->getMinHost()
+                  << " maxHost: " << *sub->getMaxHost() << '\n';
     }
 
     return a.exec();

--- a/src/console/main.cpp
+++ b/src/console/main.cpp
@@ -21,22 +21,26 @@ int main(int argc, char *argv[])
     try {
         std::cin >> mainNetwork.Ip;
     } catch (const IPFormatExcept& e) {
-        std::cout << "\nException: " << e.what();
-        return 1; //should return something more meaningful
+        std::cout << "\nException: " << e.what() << '\n';
+        return 1; //TODO: should return something more meaningful
     }
 
     std::cout << "Podaj maske IPv4 sieci glownej: ";
     try {
         std::cin >> mainNetwork.NetMask;
     } catch (const IPFormatExcept& e) {
-        std::cout << "\nException: " << e.what();
+        std::cout << "\nException: " << e.what() << '\n';
         return 1; //TODO: should return something more meaningful
     }
 
-    if(mainNetwork.isHost(*mainNetwork.Ip)) //without this UNDEFINED BEHAVIOR
+    if(mainNetwork.isHost(*mainNetwork.Ip)) //without this UNDEFINED BEHAVIOR until using ctor for object mainNetwork
     {
+        std::cout << "Warning: Podane IP sieci jest IP hosta dla podanej maski!\n";
         mainNetwork.fix();
     }
+
+    std::cout << "IP sieci glownej: " << *mainNetwork.Ip << '\n'
+              << "Maska sieci glownej: " << *mainNetwork.NetMask << '\n';
 
     std::cout << "Ile sieci zaadresowac?: ";
     int networkNumber = 0;
@@ -59,13 +63,13 @@ int main(int argc, char *argv[])
     try {
         calc.calcSubnets(mainNetwork, subnets);
     } catch (const IPSubnetworkExcept& e) {
-        std::cout << "\nException: " << e.what();
+        std::cout << "\nException: " << e.what() << '\n';
         return 1; //TODO: should return something more meaningful
     }
 
     for(const auto& sub : subnets)
     {
-        std::cout << "\nNazwa podsieci: " << sub->SubName // print subnetwork name instead
+        std::cout << "\nNazwa podsieci: " << sub->SubName
                   << " IP: " << *sub->Ip
                   << " Maska: " << *sub->NetMask;
     }

--- a/src/console/main.cpp
+++ b/src/console/main.cpp
@@ -18,13 +18,24 @@ int main(int argc, char *argv[])
     Networkv4 mainNetwork;
 
     std::cout << "Podaj adres IPv4 sieci glownej: ";
-    std::cin >> mainNetwork.Ip;
-    std::cout << "Podaj maske IPv4 sieci glownej: ";
-    std::cin >> mainNetwork.NetMask;
+    try {
+        std::cin >> mainNetwork.Ip;
+    } catch (const IPFormatExcept& e) {
+        std::cout << "\nException: " << e.what();
+        return 1; //should return something more meaningful
+    }
 
-    if(*mainNetwork.Ip != *(mainNetwork.Ip & mainNetwork.NetMask))
+    std::cout << "Podaj maske IPv4 sieci glownej: ";
+    try {
+        std::cin >> mainNetwork.NetMask;
+    } catch (const IPFormatExcept& e) {
+        std::cout << "\nException: " << e.what();
+        return 1; //TODO: should return something more meaningful
+    }
+
+    if(mainNetwork.isHost(*mainNetwork.Ip)) //without this UNDEFINED BEHAVIOR
     {
-        throw NotImplemented{"TODO: error handling"}; //check if passed address is network address
+        mainNetwork.fix();
     }
 
     std::cout << "Ile sieci zaadresowac?: ";
@@ -33,7 +44,7 @@ int main(int argc, char *argv[])
 
     std::vector<std::shared_ptr<Subnet>> subnets;
 
-    for(int i = 0; i< networkNumber; i++)
+    for(int i = 0; i < networkNumber; i++)
     {
         Subnetv4 tempSubnet;
         std::cout << "Podaj nazwe podsieci [" << i << "]: ";
@@ -45,14 +56,18 @@ int main(int argc, char *argv[])
 
     SubnetsCalculatorV4 calc;
 
-    calc.calcSubnets(mainNetwork, subnets);
+    try {
+        calc.calcSubnets(mainNetwork, subnets);
+    } catch (const IPSubnetworkExcept& e) {
+        std::cout << "\nException: " << e.what();
+        return 1; //TODO: should return something more meaningful
+    }
 
-    for(int i = 0; i < networkNumber; i++)
+    for(const auto& sub : subnets)
     {
-        std::cout << "\nPodsiec [" << i << "] - "
-                  << "Nazwa podsieci: " << subnets.at(i)->SubName
-                  << " IP: " << *subnets.at(i)->Ip
-                  << " Maska: " << *subnets.at(i)->NetMask;
+        std::cout << "\nNazwa podsieci: " << sub->SubName // print subnetwork name instead
+                  << " IP: " << *sub->Ip
+                  << " Maska: " << *sub->NetMask;
     }
 
     return a.exec();

--- a/src/console/main.cpp
+++ b/src/console/main.cpp
@@ -36,12 +36,10 @@ int main(int argc, char *argv[])
     for(int i = 0; i< networkNumber; i++)
     {
         Subnetv4 tempSubnet;
-        std::cout << "Ilosc hostow w sieci [" << i << "]: ";
+        std::cout << "Podaj nazwe podsieci [" << i << "]: ";
+        std::cin >> tempSubnet.SubName;
+        std::cout << "Ilosc hostow w podsieci [" << i << "]: ";
         std::cin >> tempSubnet.HostNumber;
-        std::cout << "Podaj nazwe podsieci : ";
-        std::string name;
-        std::cin >> name;
-        tempSubnet.SubName = QString::fromStdString(name);
         subnets.push_back(std::make_shared<Subnetv4>(tempSubnet));
     }
 
@@ -51,9 +49,10 @@ int main(int argc, char *argv[])
 
     for(int i = 0; i < networkNumber; i++)
     {
-        std::cout << "\nNazwa podsieci: " << subnets.at(i)->SubName.toStdString();
-        std::cout << " Siec [" << i << "] - IP: " << *subnets.at(i)->Ip;
-        std::cout << " Maska: " << *subnets.at(i)->NetMask;
+        std::cout << "\nPodsiec [" << i << "] - "
+                  << "Nazwa podsieci: " << subnets.at(i)->SubName
+                  << " IP: " << *subnets.at(i)->Ip
+                  << " Maska: " << *subnets.at(i)->NetMask;
     }
 
     return a.exec();

--- a/src/core/IIPaddress.h
+++ b/src/core/IIPaddress.h
@@ -10,9 +10,14 @@ namespace core{
     public:
         virtual QString asStringDec() const = 0;
         virtual QString asStringBin() const = 0;
-    protected:
-        IIPaddress& operator=(const IIPaddress&) = default;
+
         virtual ~IIPaddress() = default;
+    protected:
+        IIPaddress() = default;
+        IIPaddress(const IIPaddress&) = default;
+        IIPaddress& operator=(const IIPaddress&) = default;
+        IIPaddress(IIPaddress&&) noexcept = default;
+        IIPaddress& operator=(IIPaddress&&) noexcept = default;
     };
 };
 

--- a/src/core/IIPaddress.h
+++ b/src/core/IIPaddress.h
@@ -10,7 +10,6 @@ namespace core{
     public:
         virtual QString asStringDec() const = 0;
         virtual QString asStringBin() const = 0;
-
     protected:
         IIPaddress& operator=(const IIPaddress&) = default;
         virtual ~IIPaddress() = default;

--- a/src/core/IIPmask.h
+++ b/src/core/IIPmask.h
@@ -7,7 +7,6 @@ namespace core {
     {
     public:
         virtual short getPrefix() const = 0;
-
     protected:
         IIPmask& operator=(const IIPmask&) = default;
         virtual ~IIPmask() = default;

--- a/src/core/IIPmask.h
+++ b/src/core/IIPmask.h
@@ -7,6 +7,7 @@ namespace core {
     {
     public:
         virtual short getPrefix() const = 0;
+        virtual short getLength() const = 0;
 
         virtual ~IIPmask() = default;
     protected:

--- a/src/core/IIPmask.h
+++ b/src/core/IIPmask.h
@@ -7,9 +7,14 @@ namespace core {
     {
     public:
         virtual short getPrefix() const = 0;
-    protected:
-        IIPmask& operator=(const IIPmask&) = default;
+
         virtual ~IIPmask() = default;
+    protected:
+        IIPmask() = default;
+        IIPmask(const IIPmask&) = default;
+        IIPmask& operator=(const IIPmask&) = default;
+        IIPmask(IIPmask&&) noexcept = default;
+        IIPmask& operator=(IIPmask&&) noexcept = default;
     };
 };
 

--- a/src/core/IIPparser.h
+++ b/src/core/IIPparser.h
@@ -14,9 +14,14 @@ namespace core{
     public:
         virtual std::shared_ptr<IPaddressBase> ipFromString(const QString&) const = 0;
         virtual std::shared_ptr<IPmaskBase> ipMaskFromString(const QString&) const = 0;
-    protected:
-        IIPparser& operator=(const IIPparser&) = default;
+
         virtual ~IIPparser() = default;
+    protected:
+        IIPparser() = default;
+        IIPparser(const IIPparser&) = default;
+        IIPparser& operator=(const IIPparser&) = default;
+        IIPparser(IIPparser&&) noexcept = default;
+        IIPparser& operator=(IIPparser&&) noexcept = default;
     };
 };
 

--- a/src/core/IIPparser.h
+++ b/src/core/IIPparser.h
@@ -14,7 +14,6 @@ namespace core{
     public:
         virtual std::shared_ptr<IPaddressBase> ipFromString(const QString&) const = 0;
         virtual std::shared_ptr<IPmaskBase> ipMaskFromString(const QString&) const = 0;
-
     protected:
         IIPparser& operator=(const IIPparser&) = default;
         virtual ~IIPparser() = default;

--- a/src/core/IPaddressBase.cpp
+++ b/src/core/IPaddressBase.cpp
@@ -11,11 +11,6 @@
 
 
 namespace core {
-    std::shared_ptr<IPaddressBase> operator&(const std::shared_ptr<IPaddressBase>& ip, const std::shared_ptr<IPmaskBase>& mask)
-    {
-        return ip->_applyMask(mask->_IpAddress);
-    };
-
     std::shared_ptr<IPaddressBase> operator&(const IPaddressBase& ip, const IPmaskBase& mask)
     {
         return ip._applyMask(mask._IpAddress);

--- a/src/core/IPaddressBase.cpp
+++ b/src/core/IPaddressBase.cpp
@@ -16,6 +16,11 @@ namespace core {
         return ip->_applyMask(mask->_IpAddress);
     };
 
+    std::shared_ptr<IPaddressBase> operator&(const IPaddressBase& ip, const IPmaskBase& mask)
+    {
+        return ip._applyMask(mask._IpAddress);
+    };
+
     std::istream& operator>>(std::istream& in, std::shared_ptr<IPaddressBase>& b)
     {
         std::string tempS;

--- a/src/core/IPaddressBase.h
+++ b/src/core/IPaddressBase.h
@@ -16,11 +16,9 @@ namespace core {
     public:
         IPaddressBase(const boost::dynamic_bitset<>& ipaddress): _IpAddress{ipaddress} {};
 
-        friend std::shared_ptr<IPaddressBase> operator&(const std::shared_ptr<IPaddressBase>& ip, const std::shared_ptr<IPmaskBase>& mask);
         friend std::shared_ptr<IPaddressBase> operator&(const IPaddressBase& ip, const IPmaskBase& mask);
         bool operator==(const IPaddressBase&) const;
         bool operator!=(const IPaddressBase&) const;
-
 
         friend std::istream& operator>>(std::istream&, std::shared_ptr<IPaddressBase>&);
 

--- a/src/core/IPaddressBase.h
+++ b/src/core/IPaddressBase.h
@@ -17,6 +17,7 @@ namespace core {
         IPaddressBase(const boost::dynamic_bitset<>& ipaddress): _IpAddress{ipaddress} {};
 
         friend std::shared_ptr<IPaddressBase> operator&(const std::shared_ptr<IPaddressBase>& ip, const std::shared_ptr<IPmaskBase>& mask);
+        friend std::shared_ptr<IPaddressBase> operator&(const IPaddressBase& ip, const IPmaskBase& mask);
         bool operator==(const IPaddressBase&) const;
         bool operator!=(const IPaddressBase&) const;
 

--- a/src/core/IPaddressBase.h
+++ b/src/core/IPaddressBase.h
@@ -28,6 +28,8 @@ namespace core {
     protected:
         virtual std::shared_ptr<IPaddressBase> _applyMask(const boost::dynamic_bitset<>& maskBitset) const = 0;
 
+//        IPaddressBase& operator=(const IPaddressBase&) = default; //no neeed to prevent slicing, as long as derived class doesn't have more members
+
         boost::dynamic_bitset<> _IpAddress;
     };
 };

--- a/src/core/IPmaskBase.cpp
+++ b/src/core/IPmaskBase.cpp
@@ -24,12 +24,17 @@ namespace core{
             };
         };
 
-        throw IPinvalidFormat("Passed value cannot be converted into valid IP version 4 mask");
+        throw IPFormatExcept("Passed value cannot be converted into valid IP version 4 mask");
     };
 
     short IPmaskBase::getPrefix() const
     {
         return static_cast<short>(_IpAddress.count());
+    }
+
+    short IPmaskBase::getLength() const
+    {
+        return static_cast<short>(_IpAddress.size());
     };
 
     std::istream& operator>>(std::istream& in, std::shared_ptr<IPmaskBase>& b)

--- a/src/core/IPmaskBase.cpp
+++ b/src/core/IPmaskBase.cpp
@@ -1,7 +1,6 @@
 #include "IPmaskBase.h"
 
 #include <boost/dynamic_bitset.hpp>
-#include <stdexcept>
 #include <istream>
 #include <memory>
 #include <string>
@@ -24,7 +23,8 @@ namespace core{
                 if(maskAddress == bits) return;
             };
         };
-        throw std::invalid_argument("IP is not a mask");
+
+        throw IPinvalidFormat("Passed value cannot be converted into valid IP version 4 mask");
     };
 
     short IPmaskBase::getPrefix() const

--- a/src/core/IPmaskBase.h
+++ b/src/core/IPmaskBase.h
@@ -12,6 +12,7 @@ namespace core {
         IPmaskBase(const boost::dynamic_bitset<>& maskAddress);
 
         short getPrefix() const final;
+        short getLength() const final;
 
         friend std::istream& operator>>(std::istream&, std::shared_ptr<IPmaskBase>&);
 

--- a/src/core/IPmaskBase.h
+++ b/src/core/IPmaskBase.h
@@ -16,6 +16,8 @@ namespace core {
         friend std::istream& operator>>(std::istream&, std::shared_ptr<IPmaskBase>&);
 
         virtual ~IPmaskBase() = default;
+    protected:
+//        IPmaskBase& operator=(const IPmaskBase&) = default; //no neeed to prevent slicing, as long as derived class doesn't have more members
     };
 };
 

--- a/src/core/IPstructs.h
+++ b/src/core/IPstructs.h
@@ -50,6 +50,10 @@ namespace core {
         long long int HostNumber = -10;
         QString SubName = "blank";
 
+        virtual std::unique_ptr<IPaddressBase> getMinHost() = 0;
+        virtual std::unique_ptr<IPaddressBase> getMaxHost() = 0;
+        virtual std::unique_ptr<IPaddressBase> getBroadcast() = 0;
+
         std::shared_ptr<Subnet> clone() const
         {
             return std::shared_ptr<Subnet>(_cloneImpl());
@@ -89,6 +93,23 @@ namespace core {
         virtual unsigned long long hostsCapacity() const override
         {
             return NetworkBase::hostsCapacity() - 1; //without broadcast
+        }
+        std::unique_ptr<IPaddressBase> getMinHost() override
+        {
+            auto x = boost::dynamic_bitset<>(32, 1);
+            return std::make_unique<IPv4address>(dynamic_cast<IPv4address&>(*Ip) | IPv4address{x});
+        }
+        std::unique_ptr<IPaddressBase> getMaxHost() override
+        {
+            auto x = boost::dynamic_bitset<>(32);
+            x.set(1, 32 - NetMask->getPrefix() - 1, true);
+            return std::make_unique<IPv4address>(dynamic_cast<IPv4address&>(*Ip) | IPv4address{x});
+        }
+        std::unique_ptr<IPaddressBase> getBroadcast() override
+        {
+            auto x = boost::dynamic_bitset<>(32);
+            x.set(0, 32 - NetMask->getPrefix(), true);
+            return std::make_unique<IPv4address>(dynamic_cast<IPv4address&>(*Ip) | IPv4address{x});
         }
     private:
         virtual Subnetv4* _cloneImpl() const override

--- a/src/core/IPstructs.h
+++ b/src/core/IPstructs.h
@@ -8,35 +8,94 @@
 #include "IPv4mask.h"
 
 namespace core {
-    struct NetworkBase
+    class NetworkBase
     {
+    public:
         std::shared_ptr<IPaddressBase> Ip;
         std::shared_ptr<IPmaskBase> NetMask;
 
-        bool isHost(const IPaddressBase& hostIP) const{
-            if(*Ip == *(hostIP & *NetMask) )
-                return true;
-            else
-                return false;
+        bool isHost(const IPaddressBase& hostIP) const
+        {
+            return *Ip == *(hostIP & *NetMask) ? true : false;
         };
+        virtual unsigned long long hostsCapacity() const
+        {
+            auto allAddresses = 1ull << (NetMask->getLength() - NetMask->getPrefix());
+            return allAddresses - 1; //without network address
+        }
+
+        std::shared_ptr<NetworkBase> clone() const
+        {
+            return std::shared_ptr<NetworkBase>(_cloneImpl());
+        }
 
         virtual ~NetworkBase() = default;
+    protected:
+        NetworkBase() = default;
+        NetworkBase(const NetworkBase&) = default;
+        NetworkBase& operator=(const NetworkBase&) = default;
+        NetworkBase(NetworkBase&&) noexcept = default;
+        NetworkBase& operator=(NetworkBase&&) noexcept = default;
+    private:
+        virtual NetworkBase* _cloneImpl() const = 0;
     };
 
-    struct Subnet: public NetworkBase
+    class Subnet: public NetworkBase
     {
+    public:
         long long int HostNumber = -10;
         QString SubName = "blank";
+
+        std::shared_ptr<Subnet> clone() const
+        {
+            return std::shared_ptr<Subnet>(_cloneImpl());
+        }
+    protected:
+        Subnet() = default;
+        Subnet(const Subnet&) = default;
+        Subnet& operator=(const Subnet&) = default;
+        Subnet(Subnet&&) noexcept = default;
+        Subnet& operator=(Subnet&&) noexcept = default;
+    private:
+        Subnet* _cloneImpl() const override = 0;
     };
 
-    struct Networkv4: NetworkBase
+    class Networkv4: public NetworkBase
     {
+    public:
         Networkv4() { Ip = std::make_shared<IPv4address>(); NetMask = std::make_shared<IPv4mask>(); };
+        virtual unsigned long long hostsCapacity() const override
+        {
+            return NetworkBase::hostsCapacity() - 1; //without broadcast
+        }
+    private:
+        virtual Networkv4* _cloneImpl() const override
+        {
+            auto ptr = new Networkv4;
+            *ptr->Ip = *this->Ip;
+            *ptr->NetMask = *this->NetMask;
+            return ptr;
+        }
     };
 
-    struct Subnetv4: public Subnet
+    class Subnetv4: public Subnet
     {
+    public:
         Subnetv4() { Ip = std::make_shared<IPv4address>(); NetMask = std::make_shared<IPv4mask>(); };
+        virtual unsigned long long hostsCapacity() const override
+        {
+            return NetworkBase::hostsCapacity() - 1; //without broadcast
+        }
+    private:
+        virtual Subnetv4* _cloneImpl() const override
+        {
+            auto ptr = new Subnetv4;
+            *ptr->Ip = *this->Ip;
+            *ptr->NetMask = *this->NetMask;
+            ptr->HostNumber = this->HostNumber;
+            ptr->SubName = this->SubName;
+            return ptr;
+        }
     };
 };
 

--- a/src/core/IPstructs.h
+++ b/src/core/IPstructs.h
@@ -16,7 +16,7 @@ namespace core {
 
         bool isHost(const IPaddressBase& hostIP) const
         {
-            return *(*Ip & *NetMask) == *(hostIP & *NetMask) ? true : false;
+            return ( (*(*Ip & *NetMask) == *(hostIP & *NetMask)) && (hostIP != *Ip) ) ? true : false;
         };
         virtual unsigned long long hostsCapacity() const
         {

--- a/src/core/IPstructs.h
+++ b/src/core/IPstructs.h
@@ -12,6 +12,15 @@ namespace core {
     {
         std::shared_ptr<IPaddressBase> Ip;
         std::shared_ptr<IPmaskBase> NetMask;
+
+        bool isHost(const IPaddressBase& hostIP) const{
+            if(*Ip == *(hostIP & *NetMask) )
+                return true;
+            else
+                return false;
+        };
+
+        virtual ~NetworkBase() = default;
     };
 
     struct Subnet: public NetworkBase

--- a/src/core/IPstructs.h
+++ b/src/core/IPstructs.h
@@ -16,13 +16,17 @@ namespace core {
 
         bool isHost(const IPaddressBase& hostIP) const
         {
-            return *Ip == *(hostIP & *NetMask) ? true : false;
+            return *(*Ip & *NetMask) == *(hostIP & *NetMask) ? true : false;
         };
         virtual unsigned long long hostsCapacity() const
         {
             auto allAddresses = 1ull << (NetMask->getLength() - NetMask->getPrefix());
             return allAddresses - 1; //without network address
         }
+        void fix()
+        {
+            Ip = *Ip & *NetMask;
+        };
 
         std::shared_ptr<NetworkBase> clone() const
         {

--- a/src/core/IPv4address.cpp
+++ b/src/core/IPv4address.cpp
@@ -12,7 +12,7 @@ namespace core {
     IPv4address::IPv4address(const boost::dynamic_bitset<> &ipaddress): IPaddressBase(ipaddress)
     {
         if(ipaddress.size() != 32)
-            throw IPinvalidFormat{"Passed value cannot be converted into valid IP version 4"};
+            throw IPFormatExcept{"Passed value cannot be converted into valid IP version 4"};
     }
 
     QString IPv4address::asStringDec() const

--- a/src/core/IPv4address.cpp
+++ b/src/core/IPv4address.cpp
@@ -6,7 +6,15 @@
 #include <string>
 #include <memory>
 
+#include "coreUtils.h"
+
 namespace core {
+    IPv4address::IPv4address(const boost::dynamic_bitset<> &ipaddress): IPaddressBase(ipaddress)
+    {
+        if(ipaddress.size() != 32)
+            throw IPinvalidFormat{"Passed value cannot be converted into valid IP version 4"};
+    }
+
     QString IPv4address::asStringDec() const
     {
         return boost::asio::ip::make_address_v4(_IpAddress.to_ulong()).to_string().c_str();

--- a/src/core/IPv4address.h
+++ b/src/core/IPv4address.h
@@ -12,13 +12,12 @@ namespace core{
     {
     public:
         IPv4address(): IPaddressBase(boost::dynamic_bitset<>(32)) {};
-        IPv4address(const boost::dynamic_bitset<>& ipaddress): IPaddressBase(ipaddress) {};
+        IPv4address(const boost::dynamic_bitset<>& ipaddress);
 
         QString asStringDec() const override;
         QString asStringBin() const override;
 
         IPv4address operator| (const IPv4address& var) const;
-
     protected:
         std::shared_ptr<IPaddressBase> _applyMask(const boost::dynamic_bitset<>& maskBitset) const override;
     };

--- a/src/core/IPv4mask.cpp
+++ b/src/core/IPv4mask.cpp
@@ -3,6 +3,6 @@
 #include <boost/dynamic_bitset.hpp>
 
 namespace core {
-    IPv4mask::IPv4mask(const boost::dynamic_bitset<>& maskAddress): IPaddressBase{maskAddress}, IPmaskBase{maskAddress}
+    IPv4mask::IPv4mask(const boost::dynamic_bitset<>& maskAddress): IPaddressBase{maskAddress}, IPv4address{maskAddress}, IPmaskBase{maskAddress}
         {};
 };

--- a/src/core/IPv4mask.h
+++ b/src/core/IPv4mask.h
@@ -11,7 +11,11 @@ namespace core {
     class IPv4mask final: public IPv4address, public IPmaskBase
     {
     public:
-        IPv4mask() : IPaddressBase(boost::dynamic_bitset<>(32)), IPv4address(boost::dynamic_bitset<>(32)), IPmaskBase(boost::dynamic_bitset<>(32)) {};
+        IPv4mask() :
+            IPaddressBase(boost::dynamic_bitset<>(32, 4294967295)),
+            IPv4address(boost::dynamic_bitset<>(32, 4294967295)),
+            IPmaskBase(boost::dynamic_bitset<>(32, 4294967295))
+        {};
         IPv4mask(const boost::dynamic_bitset<>& maskAddress);
 
         QString asStringBin() const override { return IPv4address::asStringBin(); };

--- a/src/core/IPv4mask.h
+++ b/src/core/IPv4mask.h
@@ -11,12 +11,11 @@ namespace core {
     class IPv4mask final: public IPv4address, public IPmaskBase
     {
     public:
-        IPv4mask() : IPaddressBase(boost::dynamic_bitset<>(32)), IPmaskBase(boost::dynamic_bitset<>(32)) {};
+        IPv4mask() : IPaddressBase(boost::dynamic_bitset<>(32)), IPv4address(boost::dynamic_bitset<>(32)), IPmaskBase(boost::dynamic_bitset<>(32)) {};
         IPv4mask(const boost::dynamic_bitset<>& maskAddress);
 
         QString asStringBin() const override { return IPv4address::asStringBin(); };
         QString asStringDec() const override { return IPv4address::asStringDec(); };
-
     private:
         std::shared_ptr<IPaddressBase> _applyMask(const boost::dynamic_bitset<>& maskBitset) const override { return IPv4address::_applyMask(maskBitset); };
     };

--- a/src/core/IPv4parser.cpp
+++ b/src/core/IPv4parser.cpp
@@ -27,7 +27,7 @@ namespace core {
             auto v4address = boost::asio::ip::make_address_v4(addressString);
             return boost::dynamic_bitset<> (32, v4address.to_ulong());
         } catch (const boost::system::system_error&) {
-            throw IPinvalidFormat{"Passed string cannot be converted into valid IP version 4"};
+            throw IPFormatExcept{"Passed string cannot be converted into valid IP version 4"};
         };
     };
 };

--- a/src/core/IPv4parser.cpp
+++ b/src/core/IPv4parser.cpp
@@ -2,13 +2,13 @@
 
 #include <QString>
 #include <memory>
-#include <stdexcept>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/asio/ip/address_v4.hpp>
 #include <string>
 
 #include "IPv4address.h"
 #include "IPv4mask.h"
+#include "coreUtils.h"
 
 namespace core {
     std::shared_ptr<IPaddressBase> IPv4parser::ipFromString(const QString& IP) const
@@ -27,7 +27,7 @@ namespace core {
             auto v4address = boost::asio::ip::make_address_v4(addressString);
             return boost::dynamic_bitset<> (32, v4address.to_ulong());
         } catch (const boost::system::system_error&) {
-            std::throw_with_nested(std::runtime_error("Wrong input IP address"));
+            throw IPinvalidFormat{"Passed string cannot be converted into valid IP version 4"};
         };
     };
 };

--- a/src/core/SubnetsCalculatorV4.cpp
+++ b/src/core/SubnetsCalculatorV4.cpp
@@ -31,7 +31,7 @@ namespace core {
                 throw IPSubnetworkExcept{"IP mask pool has run out during subnetworks calculations"};
 
             auto Address = _chooseSubnetIP(*mainNet.Ip, *Mask, _subNets);
-            if(!mainNet.isHost(*Address))
+            if( (!mainNet.isHost(*Address)) && (*Address != *mainNet.Ip) )
                 throw IPSubnetworkExcept{"IP address pool has run out during subnetworks calculations"};
 
             _subNet->Ip = Address;

--- a/src/core/SubnetsCalculatorV4.h
+++ b/src/core/SubnetsCalculatorV4.h
@@ -13,10 +13,10 @@ namespace core {
     class SubnetsCalculatorV4
     {
     public:
-        int calcSubnets(const NetworkBase& mainNet, const std::vector<std::shared_ptr<Subnet>>& subNets);
+        void calcSubnets(const NetworkBase& mainNet, std::vector<std::shared_ptr<Subnet>>& subNets) const;
     private:
-        std::shared_ptr<IPmaskBase> _chooseSubnetMask(const long long& desiredHostsNumber);
-        std::shared_ptr<IPaddressBase> _chooseSubnetIP(const IPaddressBase& mainNetIP, const IIPmask& Mask, const std::vector<std::shared_ptr<Subnet>>& alreadyAssignedIPs);
+        std::shared_ptr<IPmaskBase> _chooseSubnetMask(const long long desiredHostsNumber) const;
+        std::shared_ptr<IPaddressBase> _chooseSubnetIP(const IPaddressBase& mainNetIP, const IIPmask& Mask, const std::vector<std::shared_ptr<Subnet>>& alreadyAssignedIPs) const;
     };
 };
 

--- a/src/core/coreUtils.cpp
+++ b/src/core/coreUtils.cpp
@@ -34,4 +34,8 @@ namespace core {
         return in;
     }
 
+    const char* IPexception::what() const throw()
+    {
+        return _text.c_str();
+    };
 };

--- a/src/core/coreUtils.cpp
+++ b/src/core/coreUtils.cpp
@@ -20,4 +20,18 @@ namespace core {
         out << c.asStringDec().toStdString() << std::flush;
         return out;
     };
+
+    std::ostream& operator<<(std::ostream& out, const QString& c)
+    {
+        return out << c.toStdString();
+    }
+
+    std::istream& operator>>(std::istream& in, QString& c)
+    {
+        std::string temp;
+        in >> temp;
+        c = QString{temp.c_str()};
+        return in;
+    }
+
 };

--- a/src/core/coreUtils.cpp
+++ b/src/core/coreUtils.cpp
@@ -3,7 +3,7 @@
 #include "IIPaddress.h"
 
 namespace core {
-    const char* NotImplemented::what() const throw()
+    const char* NotImplemented::what() const noexcept
     {
         return _text.c_str();
     };
@@ -33,9 +33,4 @@ namespace core {
         c = QString{temp.c_str()};
         return in;
     }
-
-    const char* IPexception::what() const throw()
-    {
-        return _text.c_str();
-    };
 };

--- a/src/core/coreUtils.cpp
+++ b/src/core/coreUtils.cpp
@@ -21,6 +21,11 @@ namespace core {
         return out;
     };
 
+    const char *IPException::what() const noexcept
+    {
+        return _text.c_str();
+    }
+
     std::ostream& operator<<(std::ostream& out, const QString& c)
     {
         return out << c.toStdString();

--- a/src/core/coreUtils.h
+++ b/src/core/coreUtils.h
@@ -16,12 +16,27 @@ namespace core {
         NotImplemented(): NotImplemented("Not Implememented", __FUNCTION__) {};
         NotImplemented(const char* message): NotImplemented(message, __FUNCTION__) {};
 
-        virtual const char *what() const throw();
-
+        virtual const char* what() const throw();
     private:
         std::string _text;
 
         NotImplemented(const char* message, const char* function);
+    };
+
+    class IPexception : public std::exception
+    {
+    public:
+        IPexception(const char* message): _text{message} {};
+
+        virtual const char* what() const throw();
+    private:
+        std::string _text;
+    };
+
+    class IPinvalidFormat : public IPexception
+    {
+    public:
+        IPinvalidFormat(const char* message) : IPexception{message} {};
     };
 
     std::ostream& operator<< (std::ostream& out, const IIPaddress& c);

--- a/src/core/coreUtils.h
+++ b/src/core/coreUtils.h
@@ -26,7 +26,11 @@ namespace core {
     class IPException : public std::exception
     {
     public:
-        IPException(const char* message): std::exception{message} {};
+        IPException(const char* message): _text{message} {};
+
+        const char * what() const noexcept override;
+    private:
+        std::string _text;
     };
 
     class IPFormatExcept : public IPException

--- a/src/core/coreUtils.h
+++ b/src/core/coreUtils.h
@@ -16,27 +16,35 @@ namespace core {
         NotImplemented(): NotImplemented("Not Implememented", __FUNCTION__) {};
         NotImplemented(const char* message): NotImplemented(message, __FUNCTION__) {};
 
-        virtual const char* what() const throw();
+        virtual const char* what() const noexcept;
     private:
         std::string _text;
 
         NotImplemented(const char* message, const char* function);
     };
 
-    class IPexception : public std::exception
+    class IPException : public std::exception
     {
     public:
-        IPexception(const char* message): _text{message} {};
-
-        virtual const char* what() const throw();
-    private:
-        std::string _text;
+        IPException(const char* message): std::exception{message} {};
     };
 
-    class IPinvalidFormat : public IPexception
+    class IPFormatExcept : public IPException
     {
     public:
-        IPinvalidFormat(const char* message) : IPexception{message} {};
+        IPFormatExcept(const char* message) : IPException{message} {};
+    };
+
+    class IPNetworkExcept : public IPException
+    {
+    public:
+        IPNetworkExcept(const char* message) : IPException{message} {};
+    };
+
+    class IPSubnetworkExcept : public IPException
+    {
+    public:
+        IPSubnetworkExcept(const char* message) : IPException{message} {};
     };
 
     std::ostream& operator<< (std::ostream& out, const IIPaddress& c);

--- a/src/core/coreUtils.h
+++ b/src/core/coreUtils.h
@@ -4,6 +4,8 @@
 
 #include <stdexcept>
 #include <string>
+#include <iostream>
+#include <QString>
 
 namespace core {
     class IIPaddress; //forward declaration
@@ -23,6 +25,8 @@ namespace core {
     };
 
     std::ostream& operator<< (std::ostream& out, const IIPaddress& c);
+    std::ostream& operator<< (std::ostream& out, const QString& c);
+    std::istream& operator>> (std::istream& in, QString& c);
 };
 
 #endif // COREUTILS_H

--- a/tests/IPstructsTests.cpp
+++ b/tests/IPstructsTests.cpp
@@ -18,6 +18,9 @@ namespace IPstructsTests {
         SECTION("Host capacity test"){
             CHECK(network.hostsCapacity() == 2046);
         }
+        SECTION("IP of network treat as non host"){
+            CHECK(network.isHost(*IPv4parser{}.ipFromString("172.16.32.0")) == false);
+        }
         SECTION("Check if IP is a host of network"){
             CHECK(network.isHost(*IPv4parser{}.ipFromString("172.16.32.1")) == true);
         }

--- a/tests/IPstructsTests.cpp
+++ b/tests/IPstructsTests.cpp
@@ -11,11 +11,24 @@ namespace IPstructsTests {
         network.Ip = IPv4parser{}.ipFromString("172.16.32.0");
         network.NetMask = IPv4parser{}.ipMaskFromString("255.255.248.0");
 
+        Subnetv4 sub;
+        sub.Ip = IPv4parser{}.ipFromString("192.168.1.0");
+        sub.NetMask = IPv4parser{}.ipMaskFromString("255.255.255.252");
+
         SECTION("Host capacity test"){
             CHECK(network.hostsCapacity() == 2046);
         }
         SECTION("Check if IP is a host of network"){
             CHECK(network.isHost(*IPv4parser{}.ipFromString("172.16.32.1")) == true);
+        }
+        SECTION("Get Subnetv4 MinHost address"){
+            CHECK(sub.getMinHost()->asStringDec().toStdString() == "192.168.1.1");
+        }
+        SECTION("Get Subnetv4 MaxHost address"){
+            CHECK(sub.getMaxHost()->asStringDec().toStdString() == "192.168.1.2");
+        }
+        SECTION("Get Subnetv4 broadcast address"){
+            CHECK(sub.getBroadcast()->asStringDec().toStdString() == "192.168.1.3");
         }
     }
 }

--- a/tests/IPstructsTests.cpp
+++ b/tests/IPstructsTests.cpp
@@ -1,0 +1,21 @@
+#include <catch2/catch.hpp>
+
+#include "IPstructs.h"
+#include "IPv4parser.h"
+
+using namespace core;
+
+namespace IPstructsTests {
+    TEST_CASE("Network4 Tests"){
+        Networkv4 network;
+        network.Ip = IPv4parser{}.ipFromString("172.16.32.0");
+        network.NetMask = IPv4parser{}.ipMaskFromString("255.255.248.0");
+
+        SECTION("Host capacity test"){
+            CHECK(network.hostsCapacity() == 2046);
+        }
+        SECTION("Check if IP is a host of network"){
+            CHECK(network.isHost(*IPv4parser{}.ipFromString("172.16.32.1")) == true);
+        }
+    }
+}

--- a/tests/IPv4addressTests.cpp
+++ b/tests/IPv4addressTests.cpp
@@ -32,11 +32,11 @@ namespace IPv4addressTests {
             std::shared_ptr<IPaddressBase> left = std::make_shared<IPv4address>(ip4address);
             std::shared_ptr<IPmaskBase> right = std::make_shared<IPv4mask>(mask1);
 
-            auto expected = left & right;
+            auto expected = *left & *right;
             CHECK(expected->asStringDec() == "192.168.0.0");
 
             right = std::make_shared<IPv4mask>(mask2);
-            expected = left & right;
+            expected = *left & *right;
             CHECK(expected->asStringDec() == "192.160.0.0");
         };
         SECTION("operator =="){
@@ -50,8 +50,8 @@ namespace IPv4addressTests {
             CHECK_NOTHROW(IPv4address{bitset_ip});
         }
         SECTION("Ctors validation should throw"){
-            CHECK_THROWS_AS(IPv4address{boost::dynamic_bitset <> (33, 1)}, IPinvalidFormat);
-            CHECK_THROWS_AS(IPv4address{boost::dynamic_bitset <> (25, 1)}, IPinvalidFormat);
+            CHECK_THROWS_AS(IPv4address{boost::dynamic_bitset <> (33, 1)}, IPFormatExcept);
+            CHECK_THROWS_AS(IPv4address{boost::dynamic_bitset <> (25, 1)}, IPFormatExcept);
         }
     };
 };

--- a/tests/IPv4addressTests.cpp
+++ b/tests/IPv4addressTests.cpp
@@ -3,6 +3,7 @@
 
 #include "IPv4address.h"
 #include "IPv4mask.h"
+#include "coreUtils.h"
 
 using namespace core;
 
@@ -45,5 +46,12 @@ namespace IPv4addressTests {
         SECTION("operator !="){
             CHECK(mask1 != mask2);
         };
+        SECTION("Ctors validation should not throw"){
+            CHECK_NOTHROW(IPv4address{bitset_ip});
+        }
+        SECTION("Ctors validation should throw"){
+            CHECK_THROWS_AS(IPv4address{boost::dynamic_bitset <> (33, 1)}, IPinvalidFormat);
+            CHECK_THROWS_AS(IPv4address{boost::dynamic_bitset <> (25, 1)}, IPinvalidFormat);
+        }
     };
 };

--- a/tests/IPv4maskTests.cpp
+++ b/tests/IPv4maskTests.cpp
@@ -33,7 +33,7 @@ namespace IPv4maskTests {
             };
         };
         SECTION("Get proper ipv4 prefix"){
-            CHECK(IPv4mask(boost::dynamic_bitset<> {32, 4294967232}).getPrefix() == 26); //255.255.255.255
+            CHECK(IPv4mask(boost::dynamic_bitset<> {32, 4294967232}).getPrefix() == 26); //255.255.255.192
         };
         SECTION("Default constructed mask should have all bit set to 1"){
             CHECK(IPv4mask{}.getPrefix() == 32);

--- a/tests/IPv4maskTests.cpp
+++ b/tests/IPv4maskTests.cpp
@@ -29,7 +29,7 @@ namespace IPv4maskTests {
         WHEN("Mask is invalid format"){
             boost::dynamic_bitset<> bitset_ip{32, 3232235521}; //192.168.0.1
             THEN("Ctor throws error"){
-                CHECK_THROWS_AS(IPv4mask{bitset_ip}, IPinvalidFormat);
+                CHECK_THROWS_AS(IPv4mask{bitset_ip}, IPFormatExcept);
             };
         };
         SECTION("Get proper ipv4 prefix"){

--- a/tests/IPv4maskTests.cpp
+++ b/tests/IPv4maskTests.cpp
@@ -2,9 +2,9 @@
 #include <boost/dynamic_bitset.hpp>
 #include <vector>
 #include <string>
-#include <stdexcept>
 
 #include "IPv4mask.h"
+#include "coreUtils.h"
 
 using namespace core;
 
@@ -29,7 +29,7 @@ namespace IPv4maskTests {
         WHEN("Mask is invalid format"){
             boost::dynamic_bitset<> bitset_ip{32, 3232235521}; //192.168.0.1
             THEN("Ctor throws error"){
-                CHECK_THROWS_AS(IPv4mask{bitset_ip}, std::invalid_argument);
+                CHECK_THROWS_AS(IPv4mask{bitset_ip}, IPinvalidFormat);
             };
         };
         SECTION("Get proper ipv4 prefix"){

--- a/tests/IPv4maskTests.cpp
+++ b/tests/IPv4maskTests.cpp
@@ -21,7 +21,7 @@ namespace IPv4maskTests {
             {
                 std::string temps;
                 to_string(element, temps);
-                THEN(std::string("Object created: ") + temps){
+                THEN(std::string{"Object created: "} + temps){
                     CHECK_NOTHROW(IPv4mask{element});
                 };
             };
@@ -33,8 +33,10 @@ namespace IPv4maskTests {
             };
         };
         SECTION("Get proper ipv4 prefix"){
-            CHECK(IPv4mask().getPrefix() == 0);
-            CHECK(IPv4mask(boost::dynamic_bitset<> {32, 4294967295}).getPrefix() == 32); //255.255.255.255
+            CHECK(IPv4mask(boost::dynamic_bitset<> {32, 4294967232}).getPrefix() == 26); //255.255.255.255
+        };
+        SECTION("Default constructed mask should have all bit set to 1"){
+            CHECK(IPv4mask{}.getPrefix() == 32);
         };
     };
 };

--- a/tests/IPv4parserTests.cpp
+++ b/tests/IPv4parserTests.cpp
@@ -1,8 +1,8 @@
 #include <catch2/catch.hpp>
-#include <stdexcept>
 #include <boost/dynamic_bitset.hpp>
 
 #include "IPv4parser.h"
+#include "coreUtils.h"
 
 using namespace core;
 
@@ -14,20 +14,20 @@ namespace IPv4parserTest {
             CHECK_NOTHROW(ip4parser.ipFromString("192.168.0.1"));
         };
         SECTION("Parsing string with invalid ip address"){
-            CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.256"), std::nested_exception);
-            CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.255/21"), std::nested_exception);
-            CHECK_THROWS_AS(ip4parser.ipFromString("foobar"), std::nested_exception);
-            CHECK_THROWS_AS(ip4parser.ipFromString("fe80::1"), std::nested_exception);
+            CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.256"), IPinvalidFormat);
+            CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.255/21"), IPinvalidFormat);
+            CHECK_THROWS_AS(ip4parser.ipFromString("foobar"), IPinvalidFormat);
+            CHECK_THROWS_AS(ip4parser.ipFromString("fe80::1"), IPinvalidFormat);
         };
 
         SECTION("Parsing string with valid ip mask address into IPmask object"){
             CHECK_NOTHROW(ip4parser.ipMaskFromString("255.255.255.128"));
         };
         SECTION("Parsing string with invalid ip mask address"){
-            CHECK_THROWS_AS(ip4parser.ipMaskFromString("255.256.0.0"), std::nested_exception);
-            CHECK_THROWS_AS(ip4parser.ipMaskFromString("255.0.0.0/21"), std::nested_exception);
-            CHECK_THROWS_AS(ip4parser.ipMaskFromString("foobar"), std::nested_exception);
-            CHECK_THROWS_AS(ip4parser.ipMaskFromString("fe80::1"), std::nested_exception);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("255.256.0.0"), IPinvalidFormat);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("255.0.0.0/21"), IPinvalidFormat);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("foobar"), IPinvalidFormat);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("fe80::1"), IPinvalidFormat);
         };
     };
 };

--- a/tests/IPv4parserTests.cpp
+++ b/tests/IPv4parserTests.cpp
@@ -14,20 +14,20 @@ namespace IPv4parserTest {
             CHECK_NOTHROW(ip4parser.ipFromString("192.168.0.1"));
         };
         SECTION("Parsing string with invalid ip address"){
-            CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.256"), IPinvalidFormat);
-            CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.255/21"), IPinvalidFormat);
-            CHECK_THROWS_AS(ip4parser.ipFromString("foobar"), IPinvalidFormat);
-            CHECK_THROWS_AS(ip4parser.ipFromString("fe80::1"), IPinvalidFormat);
+            CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.256"), IPFormatExcept);
+            CHECK_THROWS_AS(ip4parser.ipFromString("192.168.0.255/21"), IPFormatExcept);
+            CHECK_THROWS_AS(ip4parser.ipFromString("foobar"), IPFormatExcept);
+            CHECK_THROWS_AS(ip4parser.ipFromString("fe80::1"), IPFormatExcept);
         };
 
         SECTION("Parsing string with valid ip mask address into IPmask object"){
             CHECK_NOTHROW(ip4parser.ipMaskFromString("255.255.255.128"));
         };
         SECTION("Parsing string with invalid ip mask address"){
-            CHECK_THROWS_AS(ip4parser.ipMaskFromString("255.256.0.0"), IPinvalidFormat);
-            CHECK_THROWS_AS(ip4parser.ipMaskFromString("255.0.0.0/21"), IPinvalidFormat);
-            CHECK_THROWS_AS(ip4parser.ipMaskFromString("foobar"), IPinvalidFormat);
-            CHECK_THROWS_AS(ip4parser.ipMaskFromString("fe80::1"), IPinvalidFormat);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("255.256.0.0"), IPFormatExcept);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("255.0.0.0/21"), IPFormatExcept);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("foobar"), IPFormatExcept);
+            CHECK_THROWS_AS(ip4parser.ipMaskFromString("fe80::1"), IPFormatExcept);
         };
     };
 };

--- a/tests/SubnetsCalculatorV4Tests.cpp
+++ b/tests/SubnetsCalculatorV4Tests.cpp
@@ -29,7 +29,7 @@ namespace SubnetsCalculatorV4Tests {
             subs.back()->HostNumber = 10;
 
             SubnetsCalculatorV4 calc;
-            CHECK_NOTHROW(calc.calcSubnets(net, subs));
+            REQUIRE_NOTHROW(calc.calcSubnets(net, subs));
 
             SECTION("Check mask addresses"){
                 for(const auto& sub : subs)
@@ -69,7 +69,7 @@ namespace SubnetsCalculatorV4Tests {
             subs.back()->HostNumber = 2;
 
             SubnetsCalculatorV4 calc;
-            CHECK_NOTHROW(calc.calcSubnets(net, subs));
+            REQUIRE_NOTHROW(calc.calcSubnets(net, subs));
 
             SECTION("Check mask addresses"){
                 std::vector<std::string> calculatedMasks{

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -7,6 +7,7 @@ CONFIG += testcase
 include(../common.pri)
 
 SOURCES += \
+    IPstructsTests.cpp \
     IPv4addressTests.cpp \
     IPv4maskTests.cpp \
     IPv4parserTests.cpp \


### PR DESCRIPTION
1. Naprawa błędnego liczenia IP z ruchomą maską.
2. Wprowadzenie obsługi błędów poprzez wyjątki z przykładem użycia w konsoli.
3. Zmienione zachowanie metody calcSubnetworks:
      - stare zachowanie: zapewnione, że kolejność podanych podsieci po obliczeniu nie będzie zmieniona,
      - nowe zachowanie: kolejność podsieci będzie posortowana od największej ilości podanych hostów, do najmniejszej.