### PR TITLE
Subnet contains hosts

### DIFF
--- a/src/console/main.cpp
+++ b/src/console/main.cpp
@@ -75,6 +75,9 @@ int main(int argc, char *argv[])
                   << " Broadcast: " << *sub->getBroadcast()
                   << "\nminHost: " << *sub->getMinHost()
                   << " maxHost: " << *sub->getMaxHost() << '\n';
+        for(const auto& host : sub->HostsList)
+            std::cout << '\t' << host.Name
+                      << *host.Ip << '\n';
     }
 
     return a.exec();

--- a/src/core/IPstructs.cpp
+++ b/src/core/IPstructs.cpp
@@ -1,0 +1,69 @@
+#include "IPstructs.h"
+
+namespace core {
+
+bool NetworkBase::isHost(const IPaddressBase &hostIP) const
+{
+    return ( (*(*Ip & *NetMask) == *(hostIP & *NetMask)) && (hostIP != *Ip) ) ? true : false;
+}
+
+unsigned long long NetworkBase::hostsCapacity() const
+{
+    auto allAddresses = 1ull << (NetMask->getLength() - NetMask->getPrefix());
+    return allAddresses - 1; //without network address
+}
+
+void NetworkBase::fix()
+{
+    Ip = *Ip & *NetMask;
+}
+
+unsigned long long Networkv4::hostsCapacity() const
+{
+    return NetworkBase::hostsCapacity() - 1; //without broadcast
+}
+
+Networkv4 *Networkv4::_cloneImpl() const
+{
+    auto ptr = new Networkv4;
+    *ptr->Ip = *this->Ip;
+    *ptr->NetMask = *this->NetMask;
+    return ptr;
+}
+
+unsigned long long Subnetv4::hostsCapacity() const
+{
+    return NetworkBase::hostsCapacity() - 1; //without broadcast
+}
+
+std::unique_ptr<IPaddressBase> Subnetv4::getMinHost()
+{
+    auto x = boost::dynamic_bitset<>(32, 1);
+    return std::make_unique<IPv4address>(dynamic_cast<IPv4address&>(*Ip) | IPv4address{x});
+}
+
+std::unique_ptr<IPaddressBase> Subnetv4::getMaxHost()
+{
+    auto x = boost::dynamic_bitset<>(32);
+    x.set(1, 32 - NetMask->getPrefix() - 1, true);
+    return std::make_unique<IPv4address>(dynamic_cast<IPv4address&>(*Ip) | IPv4address{x});
+}
+
+std::unique_ptr<IPaddressBase> Subnetv4::getBroadcast()
+{
+    auto x = boost::dynamic_bitset<>(32);
+    x.set(0, 32 - NetMask->getPrefix(), true);
+    return std::make_unique<IPv4address>(dynamic_cast<IPv4address&>(*Ip) | IPv4address{x});
+}
+
+Subnetv4 *Subnetv4::_cloneImpl() const
+{
+    auto ptr = new Subnetv4;
+    *ptr->Ip = *this->Ip;
+    *ptr->NetMask = *this->NetMask;
+    ptr->HostNumber = this->HostNumber;
+    ptr->SubName = this->SubName;
+    return ptr;
+}
+
+}

--- a/src/core/SubnetsCalculatorV4.cpp
+++ b/src/core/SubnetsCalculatorV4.cpp
@@ -12,9 +12,17 @@
 namespace core {
     void SubnetsCalculatorV4::calcSubnets(const NetworkBase& mainNet, std::vector<std::shared_ptr<Subnet>>& subNets) const
     {
+        _fillSubnetsIps(mainNet, subNets);
+
+        for(auto subnet : subNets)
+            _fillSubnetWithHosts(*subnet);
+    }
+
+    void SubnetsCalculatorV4::_fillSubnetsIps(const NetworkBase &mainNet, std::vector<std::shared_ptr<Subnet> > &subNets) const
+    {
         std::vector<std::shared_ptr<Subnet>> _subNets;
         for(const auto& sub : subNets)
-            _subNets.emplace_back() = sub->clone();
+            _subNets.emplace_back(sub->clone());
 
         std::sort(_subNets.begin(), _subNets.end(),[](const auto& a, const auto& b){
             return a->HostNumber > b->HostNumber;
@@ -43,6 +51,15 @@ namespace core {
         };
 
         subNets = _subNets;
+    };
+
+    void SubnetsCalculatorV4::_fillSubnetWithHosts(Subnet &subnet) const
+    {
+        for(auto i = 1; i <= subnet.HostNumber; i++)
+        {
+            auto host_ip = dynamic_cast<IPv4address&>(*subnet.Ip) | IPv4address{boost::dynamic_bitset<>(32,i)};
+            subnet.HostsList.emplace_back(Subnet::Host{i, QString{"Host nr "} + QString::number(i), std::make_shared<IPv4address>(host_ip)});
+        }
     };
 
     std::shared_ptr<IPmaskBase> SubnetsCalculatorV4::_chooseSubnetMask(const long long desiredHostsNumber) const
@@ -75,5 +92,5 @@ namespace core {
             netBits++;
         };
         return std::make_shared<IPv4address>(pretenderAddress);
-    };
+    }
 };

--- a/src/core/SubnetsCalculatorV4.h
+++ b/src/core/SubnetsCalculatorV4.h
@@ -15,6 +15,8 @@ namespace core {
     public:
         void calcSubnets(const NetworkBase& mainNet, std::vector<std::shared_ptr<Subnet>>& subNets) const;
     private:
+        void _fillSubnetsIps(const NetworkBase& mainNet, std::vector<std::shared_ptr<Subnet>>& subNets) const;
+        void _fillSubnetWithHosts(Subnet& subNet) const;
         std::shared_ptr<IPmaskBase> _chooseSubnetMask(const long long desiredHostsNumber) const;
         std::shared_ptr<IPaddressBase> _chooseSubnetIP(const IPaddressBase& mainNetIP, const IIPmask& Mask, const std::vector<std::shared_ptr<Subnet>>& alreadyAssignedIPs) const;
     };

--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -7,6 +7,7 @@ include(../../common.pri)
 
 SOURCES += \
     IPaddressBase.cpp \
+    IPstructs.cpp \
     IPv4address.cpp \
     IPv4mask.cpp \
     IPv4parser.cpp \

--- a/tests/SubnetsCalculatorV4Tests.cpp
+++ b/tests/SubnetsCalculatorV4Tests.cpp
@@ -10,7 +10,7 @@
 using namespace core;
 
 namespace SubnetsCalculatorV4Tests {
-    TEST_CASE("SubnetsCalculatorV4 Tests"){
+    TEST_CASE("SubnetsCalculatorV4 Integration Tests"){
         Networkv4 net;
         std::vector<std::shared_ptr<Subnet>> subs;
 
@@ -49,6 +49,7 @@ namespace SubnetsCalculatorV4Tests {
                         return x->Ip->asStringDec().toStdString() == var;
                     }));
             };
+
         };
         SECTION("Subneting with the STS exam data")
         {
@@ -97,8 +98,19 @@ namespace SubnetsCalculatorV4Tests {
 
                 for(size_t i = 0; i < 6; i++){
                     CHECK(subs.at(i)->Ip->asStringDec().toStdString() == calculatedIPs.at(i));
-                };
-            };
+                }
+            }
+
+            SECTION("Check host's IPs"){
+                REQUIRE(subs.at(2)->HostsList.size() == 7);
+                CHECK(subs.at(2)->HostsList.at(0).Ip->asStringDec().toStdString() == "23.91.45.97"); //1
+                CHECK(subs.at(2)->HostsList.at(1).Ip->asStringDec().toStdString() == "23.91.45.98"); //2
+                CHECK(subs.at(2)->HostsList.at(2).Ip->asStringDec().toStdString() == "23.91.45.99"); //3
+                CHECK(subs.at(2)->HostsList.at(3).Ip->asStringDec().toStdString() == "23.91.45.100"); //4
+                CHECK(subs.at(2)->HostsList.at(4).Ip->asStringDec().toStdString() == "23.91.45.101"); //5
+                CHECK(subs.at(2)->HostsList.at(5).Ip->asStringDec().toStdString() == "23.91.45.102"); //6
+                CHECK(subs.at(2)->HostsList.at(6).Ip->asStringDec().toStdString() == "23.91.45.103"); //7
+            }
         };
     };
 };


### PR DESCRIPTION
Metoda calcSubnets wypełnia vector HostsList dla każdej podsieci. Lista będzie zawierała tyle hostów ile podał użytkownik: HostNumber.

Dodane pola do `Subnet`:
`vector<Hosts> HostsList`

Obiekt `Host`:
- `Number`
- `Name`
- `Ip`

close #17 